### PR TITLE
Fix #19

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -68,15 +68,6 @@ $capabilities = array(
         )
     ),
 
-    'mod/moodleoverflow:submit' => array(
-        'riskbitmask'  => RISK_SPAM,
-        'captype'      => 'write',
-        'contextlevel' => CONTEXT_MODULE,
-        'archetypes'   => array(
-            'student' => CAP_ALLOW
-        )
-    ),
-
     'mod/moodleoverflow:viewdiscussion' => array(
         'captype'              => 'read',
         'contextlevel'         => CONTEXT_MODULE,

--- a/lang/en/moodleoverflow.php
+++ b/lang/en/moodleoverflow.php
@@ -39,7 +39,6 @@ $string['pluginname']             = 'Moodleoverflow';
 
 // Capabilities.
 $string['moodleoverflow:addinstance']         = 'Add a new Moodleoverflow instance';
-$string['moodleoverflow:submit']              = 'Submit moodleoverflow';
 $string['moodleoverflow:allowforcesubscribe'] = 'Allow forced subscription';
 $string['moodleoverflow:createattachment']    = 'Create attachments';
 $string['moodleoverflow:managesubscriptions'] = 'Manage subscriptions';

--- a/post.php
+++ b/post.php
@@ -754,11 +754,6 @@ $PAGE->set_heading($course->fullname);
 echo $OUTPUT->header();
 echo $OUTPUT->heading(format_string($moodleoverflow->name), 2);
 
-// Check the capabilities of the user again, just to be sure.
-if (!moodleoverflow_user_can_post_discussion($moodleoverflow)) {
-    print_error('cannotcreatediscussion', 'moodleoverflow');
-}
-
 // Show the description of the instance.
 if (!empty($moodleoverflow->intro)) {
     echo $OUTPUT->box(format_module_intro('moodleoverflow', $moodleoverflow, $cm->id), 'generalbox', 'intro');

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_moodleoverflow';
-$plugin->version = 2018021300;
+$plugin->version = 2018021301;
 $plugin->release = 'v3.4-r2';
 $plugin->requires = 2017051500;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Users could not reply to any thread if they did not also have the `:startdiscussion` permission. Removing this permission from a role prevented that role from viewing post.php at all.

This was cause by this unnecessary extra permission check. It has been removed.

This also removes the unused permission `:submit`.