### PR TITLE
Non-numeric value typo

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -943,7 +943,7 @@ function moodleoverflow_send_mails() {
                 }
 
                 // Tracing message.
-                mtrace('post ' - $post->id . ': ' . $discussion->name);
+                mtrace('post ' . $post->id . ': ' . $discussion->name);
             }
 
             // Release the memory.


### PR DESCRIPTION
The cronjob produces the following warning because of a typo.

Execute scheduled task: Moodleoverflow maintenance job to send mails (mod_moodleoverflow\task\send_mails)
... started 01:33:32. Current memory use 48.6MB.
Processing user 2
Sending 
Warning: A non-numeric value encountered in /var/www/public/overflow/mod/moodleoverflow/lib.php on line 946
Call Stack:
    0.0001     415480   1. {main}() /var/www/public/overflow/admin/cli/cron.php:0
    0.0977   14244040   2. cron_run() /var/www/public/overflow/admin/cli/cron.php:61
    0.1288   17235424   3. cron_run_scheduled_tasks(long) /var/www/public/overflow/lib/cronlib.php:73
    1.2130   50933208   4. cron_run_inner_scheduled_task(class mod_moodleoverflow\task\send_mails) /var/www/public/overflow/lib/cronlib.php:114
    1.2138   50961480   5. mod_moodleoverflow\task\send_mails->execute() /var/www/public/overflow/lib/cronlib.php:189
    1.2138   50961480   6. moodleoverflow_send_mails() /var/www/public/overflow/mod/moodleoverflow/classes/task/send_mails.php:54