### PR TITLE
Put attachments into post-content

### DIFF
--- a/templates/question.mustache
+++ b/templates/question.mustache
@@ -91,37 +91,36 @@
                         {{{ postcontent }}}
                     </div>
                 </div>
+
+                {{! Row with attachments. }}
+                <div class="attachments">
+
+                    {{! Loop through all attachments. }}
+                    {{#attachments}}
+
+                    {{! Don't display images as links}}
+                        {{#image}}
+                            <img src="{{filepath}}" alt=""/>
+                            <br>
+                        {{/image}}
+                        {{^image}}
+                            <a href="{{filepath}}">
+                                {{{icon}}}
+                            </a>
+                            <a href="{{filepath}}">
+                                {{filename}}
+                            </a>
+
+                        {{/image}}
+
+                        <br>
+                    {{/attachments}}
+
+                </div>
             </div>
 
         </div>
         {{! End of the post content row. }}
-
-        {{! Row with attachments. }}
-        <div class="attachments">
-
-            {{! Loop through all attachments. }}
-            {{#attachments}}
-
-                {{! Don't display images as links}}
-                {{#image}}
-                    <img src="{{filepath}}" alt=""/>
-                    <br>
-                {{/image}}
-                {{^image}}
-                    <a href="{{filepath}}">
-                        {{{icon}}}
-                    </a>
-                    <a href="{{filepath}}">
-                        {{filename}}
-                    </a>
-
-                {{/image}}
-
-                <br>
-            {{/attachments}}
-
-        </div>
-
         <div class="row side">
             <div class="left">
                 &nbsp;


### PR DESCRIPTION
Attachments directly underneath the vote arrows look a bit odd in my opinion. So I put the attachments into the post content row.

![before](https://user-images.githubusercontent.com/45795270/60098024-f1b92300-9754-11e9-9491-0a35375b0866.png)
![after](https://user-images.githubusercontent.com/45795270/60098016-ec5bd880-9754-11e9-9e87-64f31af4786f.png)