### PR TITLE
Added support for MSSQL databases

### DIFF
--- a/classes/privacy/data_export_helper.php
+++ b/classes/privacy/data_export_helper.php
@@ -157,11 +157,10 @@ class data_export_helper {
               INNER JOIN {moodleoverflow_posts} p ON p.discussion = d.id
               LEFT JOIN {moodleoverflow_read} fr ON fr.postid = p.id AND fr.userid = :readuserid
               LEFT JOIN {moodleoverflow_ratings} rat ON rat.id = (
-                SELECT id FROM {moodleoverflow_ratings} ra
+                SELECT MAX(id) FROM {moodleoverflow_ratings} ra
                 WHERE ra.postid = p.id OR ra.userid = :ratinguserid
-                LIMIT 1
-              )
-                   WHERE d.id = :discussionid
+              )              
+                    WHERE d.id = :discussionid
         ";
         $params = [
             'discussionid' => $discussionid,

--- a/classes/privacy/data_export_helper.php
+++ b/classes/privacy/data_export_helper.php
@@ -159,7 +159,7 @@ class data_export_helper {
               LEFT JOIN {moodleoverflow_ratings} rat ON rat.id = (
                 SELECT MAX(id) FROM {moodleoverflow_ratings} ra
                 WHERE ra.postid = p.id OR ra.userid = :ratinguserid
-              )              
+              )
                     WHERE d.id = :discussionid
         ";
         $params = [

--- a/classes/ratings.php
+++ b/classes/ratings.php
@@ -140,9 +140,8 @@ class ratings {
             // Get other ratings in the discussion.
             $sql = "SELECT *
                     FROM {moodleoverflow_ratings}
-                    WHERE discussionid = $discussion->id AND rating = $rating
-                    LIMIT 1";
-            $otherrating = $DB->get_record_sql($sql);
+                    WHERE discussionid = ? AND rating = ?";
+            $otherrating = $DB->get_record_sql($sql, [ $discussion->id, $rating ]);
 
             // If there is an old rating, update it. Else create a new rating record.
             if ($otherrating) {
@@ -347,10 +346,9 @@ class ratings {
         // Get the rating.
         $sql = "SELECT firstrated, rating
                   FROM {moodleoverflow_ratings}
-                 WHERE userid = $userid AND postid = $postid AND (rating = 1 OR rating = 2)
-                 LIMIT 1";
+                 WHERE userid = ? AND postid = ? AND (rating = 1 OR rating = 2)";
 
-        return ($DB->get_record_sql($sql));
+        return ($DB->get_record_sql($sql, [ $userid, $postid ]));
     }
 
     /**
@@ -390,9 +388,9 @@ class ratings {
                        (SELECT COUNT(rating) FROM {moodleoverflow_ratings} WHERE postid=p.id AND rating = 3) AS issolved,
                        (SELECT COUNT(rating) FROM {moodleoverflow_ratings} WHERE postid=p.id AND rating = 4) AS ishelpful
                   FROM {moodleoverflow_posts} p
-                 WHERE p.discussion = $discussionid
+                 WHERE p.discussion = ?
               GROUP BY p.id";
-        $votes = $DB->get_records_sql($sql);
+        $votes = $DB->get_records_sql($sql, [ $discussionid ]);
 
         // A single post is requested.
         if ($postid) {
@@ -596,9 +594,8 @@ class ratings {
         // Get the normal rating.
         $sql = "SELECT *
                 FROM {moodleoverflow_ratings}
-                WHERE userid = $userid AND postid = $postid AND (rating = 1 OR rating = 2)
-                LIMIT 1";
-        $rating['normal'] = $DB->get_record_sql($sql);
+                WHERE userid = ? AND postid = ? AND (rating = 1 OR rating = 2)";
+        $rating['normal'] = $DB->get_record_sql($sql, [ $userid, $postid ]);
 
         // Return the rating if it is requested.
         if ($oldrating == RATING_DOWNVOTE OR $oldrating == RATING_UPVOTE) {
@@ -608,9 +605,8 @@ class ratings {
         // Get the solved rating.
         $sql = "SELECT *
                 FROM {moodleoverflow_ratings}
-                WHERE userid = $userid AND postid = $postid AND rating = 3
-                LIMIT 1";
-        $rating['solved'] = $DB->get_record_sql($sql);
+                WHERE userid = ? AND postid = ? AND rating = 3";
+        $rating['solved'] = $DB->get_record_sql($sql, [ $userid, $postid ]);
 
         // Return the rating if it is requested.
         if ($oldrating == RATING_SOLVED) {
@@ -620,9 +616,8 @@ class ratings {
         // Get the helpful rating.
         $sql = "SELECT *
                 FROM {moodleoverflow_ratings}
-                WHERE userid = $userid AND postid = $postid AND rating = 4
-                LIMIT 1";
-        $rating['helpful'] = $DB->get_record_sql($sql);
+                WHERE userid = ? AND postid = ? AND rating = 4";
+        $rating['helpful'] = $DB->get_record_sql($sql, [ $userid, $postid ]);
 
         // Return the rating if it is requested.
         if ($oldrating == RATING_HELPFUL) {


### PR DESCRIPTION
The `LIMIT` keyword isn't used in MSSQL style databases and so it causes an error when running any of those queries. 
In most cases the LIMIT keyword is only ever used with `$DB->get_record_sql(..)` which only returns a single row by default anyway, using DB specific keywords

Additionally, there were some SQL queries where variable concatenation was used instead of query parameters, which have been changed.