### PR TITLE
don't double escape discussion subjects

### DIFF
--- a/templates/discussion_list.mustache
+++ b/templates/discussion_list.mustache
@@ -183,7 +183,7 @@
                 {{/canviewdiscussions}}
 
                 <td class="topic starter">
-                    <a href="{{ subjectlink }}">{{ subjecttext }}</a>
+                    <a href="{{ subjectlink }}">{{{ subjecttext }}}</a>
                 </td>
 
                 <td class="picture">

--- a/templates/question.mustache
+++ b/templates/question.mustache
@@ -53,7 +53,7 @@
                 {{#isfirstpost}}
                 {{! The subject. }}
                     <div class="subject" role="heading" aria-level="2">
-                        {{ subject }}
+                        {{{ subject }}}
                     </div>
                 {{/isfirstpost}}
 


### PR DESCRIPTION
This uses triple curly braces around discussion subjects in the mustache
templates to avoid double-escaping HTML entities, since format_string also escapes.

fixes #56