### PR TITLE
fix: Patched SQL dialect issue LIMIT vs TOP in favor of Microsoft SQL Server

### DIFF
--- a/classes/review.php
+++ b/classes/review.php
@@ -105,12 +105,20 @@ class review {
             $addwhere = ' AND p.id != :notpostid ';
             $params['notpostid'] = $afterpostid;
         }
+        /* Handle different SQL dialects in favor of Microsoft SQL Server */
+        if (is_a($DB, 'sqlsrv_native_moodle_database')) {
+            $top = 'TOP 1';
+            $limit = '';
+        } else {
+            $top = '';
+            $limit = 'LIMIT 1';
+        }
         $record = $DB->get_record_sql(
-            'SELECT p.id as postid, p.discussion as discussionid FROM {moodleoverflow_posts} p ' .
+            "SELECT $top p.id as postid, p.discussion as discussionid FROM {moodleoverflow_posts} p " .
             'JOIN {moodleoverflow_discussions} d ON d.id = p.discussion ' .
             "WHERE p.reviewed = 0 AND d.moodleoverflow = :moodleoverflowid AND p.created < :reviewtime $addwhere " .
             "ORDER BY $orderby p.discussion, p.id " .
-            'LIMIT 1',
+            $limit,
             $params
         );
         if ($record) {

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_moodleoverflow';
-$plugin->version = 2022110700;
-$plugin->release = 'v4.0-r4';
+$plugin->version = 2022120600;
+$plugin->release = 'v4.1-r1';
 $plugin->requires = 2020061500; // Requires Moodle 3.9+.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = array();


### PR DESCRIPTION
I stumbled over the `LIMIT` keyword which is not known for Microsoft SQL Server. For the latter `SELECT TOP` needs to be used.

![image](https://user-images.githubusercontent.com/486983/186891372-f8c7488d-f4e3-47f6-9400-bfa1a810aeb1.png)

The PR at hand here refactors the code to handle both dialects, while keeping behavior.