### PR TITLE
bug fixed, only moodleoverflow header displayed

### DIFF
--- a/post.php
+++ b/post.php
@@ -777,12 +777,8 @@ $PAGE->set_heading($course->fullname);
 
 // Display the header.
 echo $OUTPUT->header();
-echo $OUTPUT->heading(format_string($moodleoverflow->name), 2);
+echo $OUTPUT->heading('');
 
-// Show the description of the instance.
-if (!empty($moodleoverflow->intro)) {
-    echo $OUTPUT->box(format_module_intro('moodleoverflow', $moodleoverflow, $cm->id), 'generalbox', 'intro');
-}
 
 // Display the form.
 $mformpost->display();

--- a/post.php
+++ b/post.php
@@ -436,7 +436,7 @@ if (!empty($moodleoverflow)) {
 
             // Request a confirmation to delete the post.
             echo $OUTPUT->header();
-            echo $OUTPUT->heading(format_string($moodleoverflow->name), 2);
+            echo $OUTPUT->heading('');
             echo $OUTPUT->confirm(get_string("deletesureplural", "moodleoverflow", $replycount + 1),
                 "post.php?delete=$delete&confirm=$delete", $CFG->wwwroot . '/mod/moodleoverflow/discussion.php?d=' .
                 $post->discussion . '#p' . $post->id);
@@ -446,7 +446,7 @@ if (!empty($moodleoverflow)) {
 
             // Print a confirmation message.
             echo $OUTPUT->header();
-            echo $OUTPUT->heading(format_string($moodleoverflow->name), 2);
+            echo $OUTPUT->heading('');
             echo $OUTPUT->confirm(get_string("deletesure", "moodleoverflow", $replycount),
                 "post.php?delete=$delete&confirm=$delete",
                 $CFG->wwwroot . '/mod/moodleoverflow/discussion.php?d=' . $post->discussion . '#p' . $post->id);

--- a/post.php
+++ b/post.php
@@ -436,7 +436,6 @@ if (!empty($moodleoverflow)) {
 
             // Request a confirmation to delete the post.
             echo $OUTPUT->header();
-            echo $OUTPUT->heading('');
             echo $OUTPUT->confirm(get_string("deletesureplural", "moodleoverflow", $replycount + 1),
                 "post.php?delete=$delete&confirm=$delete", $CFG->wwwroot . '/mod/moodleoverflow/discussion.php?d=' .
                 $post->discussion . '#p' . $post->id);
@@ -446,7 +445,6 @@ if (!empty($moodleoverflow)) {
 
             // Print a confirmation message.
             echo $OUTPUT->header();
-            echo $OUTPUT->heading('');
             echo $OUTPUT->confirm(get_string("deletesure", "moodleoverflow", $replycount),
                 "post.php?delete=$delete&confirm=$delete",
                 $CFG->wwwroot . '/mod/moodleoverflow/discussion.php?d=' . $post->discussion . '#p' . $post->id);
@@ -777,8 +775,6 @@ $PAGE->set_heading($course->fullname);
 
 // Display the header.
 echo $OUTPUT->header();
-echo $OUTPUT->heading('');
-
 
 // Display the form.
 $mformpost->display();


### PR DESCRIPTION
#121 

Duplicate Title and Description of the moodleoverflow is removed in the post.php

Before:
![duplicate issue3](https://user-images.githubusercontent.com/119226824/229462653-f7585ec9-4ba9-407e-b986-c657c27f1a68.png)

After:
![duplicate issue4](https://user-images.githubusercontent.com/119226824/229462749-89a35cbe-8c8a-456f-9df2-01ebe0e11e8d.png)

