### PR TITLE
Fix reference to cpabaility in upgrade script

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -232,14 +232,16 @@ function xmldb_moodleoverflow_upgrade($oldversion) {
 
     if ($oldversion < 2022110700) {
 
-        foreach (get_archetype_roles('manager') as $role) {
-            unassign_capability('mod/moodleoverflow:reviewpost', $role->id);
-        }
+        if (get_capability_info('mod/moodleoverflow:reviewpost')) {
+            foreach (get_archetype_roles('manager') as $role) {
+                unassign_capability('mod/moodleoverflow:reviewpost', $role->id);
+            }
 
-        foreach (get_archetype_roles('teacher') as $role) {
-            assign_capability(
+            foreach (get_archetype_roles('teacher') as $role) {
+                assign_capability(
                     'mod/moodleoverflow:reviewpost', CAP_ALLOW, $role->id, context_system::instance()
-            );
+                );
+            }
         }
 
         // Moodleoverflow savepoint reached.


### PR DESCRIPTION
When upgrading from versions that did not yet have the mod/moodleoverflow:reviewpost capability defined the 2022110700 upgrade step breaks.