### PR TITLE
Fix/anonymoususerstats

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -143,9 +143,15 @@ class provider implements
                 INNER JOIN {modules} m ON m.id = cm.module AND m.name = :modname
                 INNER JOIN {moodleoverflow} mof ON mof.id = cm.instance
                 WHERE EXISTS (
-                    SELECT 1 FROM {moodleoverflow_discussions} d WHERE d.moodleoverflow = mof.id AND (d.userid = :duserid OR d.usermodified = :dmuserid)
+                    SELECT 1
+                    FROM {moodleoverflow_discussions} d
+                    WHERE d.moodleoverflow = mof.id AND (d.userid = :duserid OR d.usermodified = :dmuserid)
                 ) OR EXISTS (
-                    SELECT 1 FROM {moodleoverflow_posts} p WHERE p.discussion IN (SELECT id FROM {moodleoverflow_discussions} WHERE moodleoverflow = mof.id) AND p.userid = :puserid
+                    SELECT 1
+                    FROM {moodleoverflow_posts} p
+                    WHERE p.discussion IN (SELECT id
+                                           FROM {moodleoverflow_discussions}
+                                           WHERE moodleoverflow = mof.id) AND p.userid = :puserid
                 ) OR EXISTS (
                     SELECT 1 FROM {moodleoverflow_read} r WHERE r.moodleoverflowid = mof.id AND r.userid = :ruserid
                 ) OR EXISTS (

--- a/classes/ratings.php
+++ b/classes/ratings.php
@@ -477,7 +477,7 @@ class ratings {
      *
      * @return int
      */
-    private static function moodleoverflow_get_reputation_instance($moodleoverflowid, $userid = null) {
+    public static function moodleoverflow_get_reputation_instance($moodleoverflowid, $userid = null) {
         global $DB, $USER;
 
         // Get the user id.
@@ -574,7 +574,7 @@ class ratings {
      *
      * @return int
      */
-    private static function moodleoverflow_get_reputation_course($courseid, $userid = null) {
+    public static function moodleoverflow_get_reputation_course($courseid, $userid = null) {
         global $USER, $DB;
 
         // Get the userid.

--- a/classes/tables/userstats_table.php
+++ b/classes/tables/userstats_table.php
@@ -98,7 +98,6 @@ class userstats_table extends \flexible_table {
      * @return void
      */
     public function out() {
-        global $DB;
         $this->start_output();
         $this->sort_table_data($this->get_sort_order());
         $this->format_and_add_array_of_rows($this->userstatsdata, true);
@@ -194,7 +193,7 @@ class userstats_table extends \flexible_table {
         global $DB;
         // Get all userdata from a course.
         $context = \context_course::instance($this->courseid);
-        $users = get_enrolled_users($context , '',  0, $userfields = 'u.id, u.firstname, u.lastname');
+        $users = get_enrolled_users($context , '',  0, 'u.id, u.firstname, u.lastname');
 
         // Step 1.0: Build the datatable with all relevant Informations.
         $sqlquery = 'SELECT (ROW_NUMBER() OVER (ORDER BY ratings.id)) AS row_num,

--- a/classes/tables/userstats_table.php
+++ b/classes/tables/userstats_table.php
@@ -331,13 +331,7 @@ class userstats_table extends \flexible_table {
      * @return string
      */
     public function col_receivedupvotes($row) {
-        if ($row->receivedupvotes > 0) {
-            return \html_writer::tag('h5', \html_writer::start_span('badge badge-success') .
-                   $row->receivedupvotes . \html_writer::end_span());
-        } else {
-            return \html_writer::tag('h5', \html_writer::start_span('badge badge-warning') .
-                   $row->receivedupvotes . \html_writer::end_span());
-        }
+        return $this->badge_render($row->receivedupvotes);
     }
 
     /**
@@ -346,13 +340,7 @@ class userstats_table extends \flexible_table {
      * @return string
      */
     public function col_receiveddownvotes($row) {
-        if ($row->receiveddownvotes > 0) {
-            return \html_writer::tag('h5', \html_writer::start_span('badge badge-success') .
-                    $row->receiveddownvotes . \html_writer::end_span());
-        } else {
-            return \html_writer::tag('h5', \html_writer::start_span('badge badge-warning') .
-                   $row->receiveddownvotes . \html_writer::end_span());
-        }
+        return $this->badge_render($row->receiveddownvotes);
     }
 
     /**
@@ -361,13 +349,7 @@ class userstats_table extends \flexible_table {
      * @return string
      */
     public function col_forumactivity($row) {
-        if ($row->forumactivity > 0) {
-            return \html_writer::tag('h5', \html_writer::start_span('badge badge-success') .
-                   $row->forumactivity . \html_writer::end_span());
-        } else {
-            return \html_writer::tag('h5', \html_writer::start_span('badge badge-warning') .
-                   $row->forumactivity . \html_writer::end_span());
-        }
+        return $this->badge_render($row->forumactivity);
     }
 
     /**
@@ -376,13 +358,7 @@ class userstats_table extends \flexible_table {
      * @return string
      */
     public function col_forumreputation($row) {
-        if ($row->forumreputation > 0) {
-            return \html_writer::tag('h5', \html_writer::start_span('badge badge-success') .
-                   $row->forumreputation . \html_writer::end_span());
-        } else {
-            return \html_writer::tag('h5', \html_writer::start_span('badge badge-warning') .
-                   $row->forumreputation . \html_writer::end_span());
-        }
+        return $this->badge_render($row->forumreputation);
     }
 
     /**
@@ -391,13 +367,7 @@ class userstats_table extends \flexible_table {
      * @return string
      */
     public function col_courseactivity($row) {
-        if ($row->courseactivity > 0) {
-            return \html_writer::tag('h5', \html_writer::start_span('badge badge-success') .
-                   $row->courseactivity . \html_writer::end_span());
-        } else {
-            return \html_writer::tag('h5', \html_writer::start_span('badge badge-warning') .
-                   $row->courseactivity . \html_writer::end_span());
-        }
+        return $this->badge_render($row->courseactivity);
     }
 
     /**
@@ -406,12 +376,21 @@ class userstats_table extends \flexible_table {
      * @return string
      */
     public function col_coursereputation($row) {
-        if ($row->coursereputation > 0) {
+        return $this->badge_render($row->coursereputation);
+    }
+
+    /**
+     * Dependeng on the value display success or warning badge.
+     * @param int $number
+     * @return string
+     */
+    private function badge_render($number) {
+        if ($number > 0) {
             return \html_writer::tag('h5', \html_writer::start_span('badge badge-success') .
-                   $row->coursereputation . \html_writer::end_span());
+                $number . \html_writer::end_span());
         } else {
             return \html_writer::tag('h5', \html_writer::start_span('badge badge-warning') .
-                   $row->coursereputation . \html_writer::end_span());
+                $number . \html_writer::end_span());
         }
     }
     /**

--- a/classes/tables/userstats_table.php
+++ b/classes/tables/userstats_table.php
@@ -15,10 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Prints a particular instance of moodleoverflow
- *
- * You can have a rather longer description of the file as well,
- * if you like, and it can span multiple lines.
+ * Class needed in userstats.php
  *
  * @package   mod_moodleoverflow
  * @copyright 2023 Tamaro Walter

--- a/classes/tables/userstats_table.php
+++ b/classes/tables/userstats_table.php
@@ -250,7 +250,7 @@ class userstats_table extends \flexible_table {
 
                 // Did a student submit a rating?
                 // For solution marks: only count a solution if the discussion is not completely anonymous.
-                // For helpful makrs: only count helpful marks if the discussion is not any kind of anonymous.
+                // For helpful marks: only count helpful marks if the discussion is not any kind of anonymous.
                 // Up and downvotes are always counted.
                 if ($row->rateuserid == $student->id && !array_key_exists($row->rateid, $student->ratedposts) &&
                     (($row->rating == RATING_SOLVED && $row->anonymoussetting != 2) ||

--- a/lang/en/moodleoverflow.php
+++ b/lang/en/moodleoverflow.php
@@ -205,8 +205,10 @@ $string['noguesttracking'] = 'Sorry, guests are not allowed to set tracking opti
 // Strings for the userstats feature.
 $string['userstatsupvotes'] = 'Received upvotes';
 $string['userstatsdownvotes'] = 'Received downvotes';
-$string['userstatsactivity'] = 'Amount of activity';
-$string['userstatsreputation'] = 'User reputation';
+$string['userstatsforumactivity'] = 'Activity (this forum)';
+$string['userstatsforumreputation'] = 'Reputation (this forum)';
+$string['userstatscourseactivity'] = 'Activity (coursewide)';
+$string['userstatscoursereputation'] = 'Reputation (coursewide)';
 $string['helpamountofactivity'] = 'Each activity like writing a post, starting a discussion or giving a rating gives 1 point';
 $string['showuserstats'] = 'Show cumulative user statistics';
 $string['configshowuserstats'] = 'Allow teachers in courses to see statistics summarizing the activity of users in Moodleoverflows.';

--- a/styles.css
+++ b/styles.css
@@ -529,7 +529,7 @@
 }
 
 
-.moodleoverflow-statistics-table .header.c3 .helpactivityclass {
+.moodleoverflow-statistics-table .header .helpactivityclass {
     padding: 0;
     margin-left: 8px;
 }

--- a/tests/privacy_provider_test.php
+++ b/tests/privacy_provider_test.php
@@ -39,6 +39,7 @@ use mod_moodleoverflow\privacy\data_export_helper;
  * @group mod_moodleoverflow
  * @group mod_moodleoverflow_privacy
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \provider
  */
 class privacy_provider_test extends \core_privacy\tests\provider_testcase {
     /**

--- a/tests/readtracking_test.php
+++ b/tests/readtracking_test.php
@@ -36,6 +36,7 @@ require_once($CFG->dirroot . '/mod/moodleoverflow/locallib.php');
  * @package   mod_moodleoverflow
  * @copyright 2017 Kennet Winter <k_wint10@uni-muenster.de>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \readtracking
  */
 class readtracking_test extends advanced_testcase {
 

--- a/tests/subscriptions_test.php
+++ b/tests/subscriptions_test.php
@@ -36,6 +36,7 @@ require_once($CFG->dirroot . '/mod/moodleoverflow/lib.php');
  * @package   mod_moodleoverflow
  * @copyright 2017 Kennet Winter <k_wint10@uni-muenster.de>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \subscriptions
  */
 class subscriptions_test extends advanced_testcase {
 

--- a/tests/userstats_test.php
+++ b/tests/userstats_test.php
@@ -175,12 +175,10 @@ class userstats_test extends \advanced_testcase {
 
         // Get the current userstats to compare later.
         $olduserstats = $this->create_statstable();
-        $oldreceivedupvotesuser1 = $this->get_specific_userstats($olduserstats, $this->user1, 'receivedupvotes');
-        $oldreceiveddownvotesuser1 = $this->get_specific_userstats($olduserstats, $this->user1, 'receiveddownvotes');
+        $oldupvotesuser1 = $this->get_specific_userstats($olduserstats, $this->user1, 'receivedupvotes');
         $oldactivityuser1 = $this->get_specific_userstats($olduserstats, $this->user1, 'forumactivity');
 
-        $oldreceivedupvotesuser2 = $this->get_specific_userstats($olduserstats, $this->user2, 'receivedupvotes');
-        $oldreceiveddownvotesuser2 = $this->get_specific_userstats($olduserstats, $this->user2, 'receiveddownvotes');
+        $oldupvotesuser2 = $this->get_specific_userstats($olduserstats, $this->user2, 'receivedupvotes');
         $oldactivityuser2 = $this->get_specific_userstats($olduserstats, $this->user2, 'forumactivity');
 
         // User1 starts a new discussion, the forum activity shouldn't change.
@@ -208,18 +206,18 @@ class userstats_test extends \advanced_testcase {
         $this->create_upvote($this->user1, $discussion[1], $answeruser2);
         $newuserstats = $this->create_statstable();
         $newactivityuser1 = $this->get_specific_userstats($newuserstats, $this->user1, 'forumactivity');
-        $newreceivedupvotesuser2 = $this->get_specific_userstats($newuserstats, $this->user2, 'receivedupvotes');
+        $newupvotesuser2 = $this->get_specific_userstats($newuserstats, $this->user2, 'receivedupvotes');
         $this->assertEquals($oldactivityuser1 + 1, $newactivityuser1);
-        $this->assertEquals($oldreceivedupvotesuser2 + 1, $newreceivedupvotesuser2);
+        $this->assertEquals($oldupvotesuser2 + 1, $newupvotesuser2);
 
         // User2 gives the discussion starter post an upvote. #
         // Activity of User2 should change, the receivedupvotes from user1 shouln't change.
         $this->create_upvote($this->user2, $discussion[1], $starterpost);
         $newuserstats = $this->create_statstable();
         $newactivityuser2 = $this->get_specific_userstats($newuserstats, $this->user2, 'forumactivity');
-        $newreceivedupvotesuser1 = $this->get_specific_userstats($newuserstats, $this->user1, 'receivedupvotes');
+        $newupvotesuser1 = $this->get_specific_userstats($newuserstats, $this->user1, 'receivedupvotes');
         $this->assertEquals($oldactivityuser2 + 1, $newactivityuser2);
-        $this->assertEquals($oldreceivedupvotesuser1, $newreceivedupvotesuser1);
+        $this->assertEquals($oldupvotesuser1, $newupvotesuser1);
     }
 
     /**
@@ -227,18 +225,15 @@ class userstats_test extends \advanced_testcase {
      * @covers \userstats_table
      */
     public function test_total_anonymous() {
-        global $DB;
         // Test case: Only topic startes are anonymous.
         $this->make_anonymous(2);
 
         // Get the current userstats to compare later.
         $olduserstats = $this->create_statstable();
-        $oldreceivedupvotesuser1 = $this->get_specific_userstats($olduserstats, $this->user1, 'receivedupvotes');
-        $oldreceiveddownvotesuser1 = $this->get_specific_userstats($olduserstats, $this->user1, 'receiveddownvotes');
+        $oldupvotesuser1 = $this->get_specific_userstats($olduserstats, $this->user1, 'receivedupvotes');
         $oldactivityuser1 = $this->get_specific_userstats($olduserstats, $this->user1, 'forumactivity');
 
-        $oldreceivedupvotesuser2 = $this->get_specific_userstats($olduserstats, $this->user2, 'receivedupvotes');
-        $oldreceiveddownvotesuser2 = $this->get_specific_userstats($olduserstats, $this->user2, 'receiveddownvotes');
+        $oldupvotesuser2 = $this->get_specific_userstats($olduserstats, $this->user2, 'receivedupvotes');
         $oldactivityuser2 = $this->get_specific_userstats($olduserstats, $this->user2, 'forumactivity');
 
         // User1 starts a new discussion, the forum activity shouldn't change.
@@ -264,9 +259,9 @@ class userstats_test extends \advanced_testcase {
         $this->create_upvote($this->user1, $discussion[1], $answeruser2);
         $newuserstats = $this->create_statstable();
         $newactivityuser1 = $this->get_specific_userstats($newuserstats, $this->user1, 'forumactivity');
-        $newreceivedupvotesuser2 = $this->get_specific_userstats($newuserstats, $this->user2, 'receivedupvotes');
+        $newupvotesuser2 = $this->get_specific_userstats($newuserstats, $this->user2, 'receivedupvotes');
         $this->assertEquals($oldactivityuser1 + 1, $newactivityuser1);
-        $this->assertEquals($oldreceivedupvotesuser2, $newreceivedupvotesuser2);
+        $this->assertEquals($oldupvotesuser2, $newupvotesuser2);
     }
 
     // Helper functions.

--- a/tests/userstats_test.php
+++ b/tests/userstats_test.php
@@ -210,7 +210,7 @@ class userstats_test extends \advanced_testcase {
         $this->assertEquals($oldactivityuser1 + 1, $newactivityuser1);
         $this->assertEquals($oldupvotesuser2 + 1, $newupvotesuser2);
 
-        // User2 gives the discussion starter post an upvote. #
+        // User2 gives the discussion starter post an upvote.
         // Activity of User2 should change, the receivedupvotes from user1 shouln't change.
         $this->create_upvote($this->user2, $discussion[1], $starterpost);
         $newuserstats = $this->create_statstable();
@@ -388,7 +388,7 @@ class userstats_test extends \advanced_testcase {
             'discussionid' => $discussion->id,
             'userid' => $author->id,
             'postid' => $post->id,
-            'rating' => 3,
+            'rating' => 4,
             'firstrated' => time(),
             'lastchanged' => time()
         ];
@@ -410,7 +410,7 @@ class userstats_test extends \advanced_testcase {
             'discussionid' => $discussion->id,
             'userid' => $author->id,
             'postid' => $post->id,
-            'rating' => 4,
+            'rating' => 3,
             'firstrated' => time(),
             'lastchanged' => time()
         ];

--- a/tests/userstats_test.php
+++ b/tests/userstats_test.php
@@ -148,7 +148,7 @@ class userstats_test extends \advanced_testcase {
         $data = $this->create_statstable();
         foreach ($data as $student) {
             if ($student->id == $this->user1->id) {
-                $activity = $student->activity;
+                $activity = $student->forumactivity;
             }
         }
         $this->assertEquals(5, $activity);
@@ -165,13 +165,13 @@ class userstats_test extends \advanced_testcase {
         $this->create_downvote($this->user1, $this->discussion2[1], $this->post2);
         $this->create_solution($this->teacher, $this->discussion1[1], $this->answer1);
 
-        // Calculate the reputation of user2.
-        $reputation = \mod_moodleoverflow\ratings::moodleoverflow_get_reputation($this->moodleoverflow->id, $this->user2->id);
+        // Calculate the forum reputation of user2.
+        $reputation = \mod_moodleoverflow\ratings::moodleoverflow_get_reputation_instance($this->moodleoverflow->id, $this->user2->id);
         // Create the user statistics table for this course and save it in $data.
         $data = $this->create_statstable();
         foreach ($data as $student) {
             if ($student->id == $this->user2->id) {
-                $reputation2 = $student->reputation;
+                $reputation2 = $student->forumreputation;
             }
         }
         $this->assertEquals($reputation, $reputation2);


### PR DESCRIPTION
Userstats are now fully compatible with anonymous moodleoverflows.
New: 
- activity and reputation are divided in "forum" and "coursewide". The forum column shows the activity/reputation for the moodleoverflow, that opened the userstats. The coursewide column shows the activity/reputation from all moodleoverflow from one course. Note that "received up-/downvotes" are only counted coursewide:

![image](https://github.com/learnweb/moodle-mod_moodleoverflow/assets/119226824/2005b639-da90-49ee-a30e-b33c450389ae)

- Compatibility with anonymous forum: to guard the anonymity of users, not all interactions in a anonymous moodleoverflow are shown in the userstatistics. This means:
- In completely anonym moodleoverflows (all question and answer are anonym), writing a post, giving a helpful mark or receiving/ up/downvotes won't be counted in the user statistics
- In partial anonym moodleoverflows (only questions/answers from the topic starter are anonym), all activites which affect the topic starter (if the topic starter writes an answer, gives/receives an up/downvote or marks an answer as helpful) won't be shown in the user statistics. 