### PR TITLE
Fix/ratingsort

### DIFF
--- a/backup/moodle2/backup_moodleoverflow_stepslib.php
+++ b/backup/moodle2/backup_moodleoverflow_stepslib.php
@@ -44,49 +44,49 @@ class backup_moodleoverflow_activity_structure_step extends backup_activity_stru
         $userinfo = $this->get_setting_value('userinfo');
 
         // Define the root element describing the moodleoverflow instance.
-        $moodleoverflow = new backup_nested_element('moodleoverflow', array('id'), array(
+        $moodleoverflow = new backup_nested_element('moodleoverflow', ['id'], [
             'name', 'intro', 'introformat', 'maxbytes', 'maxattachments',
             'forcesubscribe', 'trackingtype', 'timecreated', 'timemodified',
-            'ratingpreference', 'coursewidereputation', 'allownegativereputation'));
+            'ratingpreference', 'coursewidereputation', 'allownegativereputation']);
 
         // Define each element separated.
         $discussions = new backup_nested_element('discussions');
-        $discussion = new backup_nested_element('discussion', array('id'), array(
-            'name', 'firstpost', 'userid', 'timemodified', 'usermodified', 'timestart'));
+        $discussion = new backup_nested_element('discussion', ['id'], [
+            'name', 'firstpost', 'userid', 'timemodified', 'usermodified', 'timestart']);
 
         $posts = new backup_nested_element('posts');
 
-        $post = new backup_nested_element('post', array('id'), array(
+        $post = new backup_nested_element('post', ['id'], [
             'parent', 'userid', 'created', 'modified',
-            'mailed', 'message', 'messageformat', 'attachment'));
+            'mailed', 'message', 'messageformat', 'attachment']);
 
         $ratings = new backup_nested_element('ratings');
 
-        $rating = new backup_nested_element('rating', array('id'), array(
-            'userid', 'rating', 'firstrated', 'lastchanged'));
+        $rating = new backup_nested_element('rating', ['id'], [
+            'userid', 'rating', 'firstrated', 'lastchanged']);
 
         $discussionsubs = new backup_nested_element('discuss_subs');
 
-        $discussionsub = new backup_nested_element('discuss_sub', array('id'), array(
+        $discussionsub = new backup_nested_element('discuss_sub', ['id'], [
             'userid',
             'preference',
-        ));
+        ]);
 
         $subscriptions = new backup_nested_element('subscriptions');
 
-        $subscription = new backup_nested_element('subscription', array('id'), array(
-            'userid'));
+        $subscription = new backup_nested_element('subscription', ['id'], [
+            'userid']);
 
         $readposts = new backup_nested_element('readposts');
 
-        $read = new backup_nested_element('read', array('id'), array(
+        $read = new backup_nested_element('read', ['id'], [
             'userid', 'discussionid', 'postid', 'firstread',
-            'lastread'));
+            'lastread']);
 
         $tracking = new backup_nested_element('tracking');
 
-        $track = new backup_nested_element('track', array('id'), array(
-            'userid'));
+        $track = new backup_nested_element('track', ['id'], [
+            'userid']);
 
         // Build the tree.
         $moodleoverflow->add_child($discussions);
@@ -111,7 +111,7 @@ class backup_moodleoverflow_activity_structure_step extends backup_activity_stru
         $tracking->add_child($track);
 
         // Define data sources.
-        $moodleoverflow->set_source_table('moodleoverflow', array('id' => backup::VAR_ACTIVITYID));
+        $moodleoverflow->set_source_table('moodleoverflow', ['id' => backup::VAR_ACTIVITYID]);
 
         // All these source definitions only happen if we are including user info.
         if ($userinfo) {
@@ -119,15 +119,15 @@ class backup_moodleoverflow_activity_structure_step extends backup_activity_stru
                 SELECT *
                   FROM {moodleoverflow_discussions}
                  WHERE moodleoverflow = ?',
-                array(backup::VAR_PARENTID));
+                [backup::VAR_PARENTID]);
 
             // Need posts ordered by id so parents are always before childs on restore.
-            $post->set_source_table('moodleoverflow_posts', array('discussion' => backup::VAR_PARENTID), 'id ASC');
-            $rating->set_source_table('moodleoverflow_ratings', array('postid' => backup::VAR_PARENTID));
-            $discussionsub->set_source_table('moodleoverflow_discuss_subs', array('discussion' => backup::VAR_PARENTID));
-            $subscription->set_source_table('moodleoverflow_subscriptions', array('moodleoverflow' => backup::VAR_PARENTID));
-            $read->set_source_table('moodleoverflow_read', array('moodleoverflowid' => backup::VAR_PARENTID));
-            $track->set_source_table('moodleoverflow_tracking', array('moodleoverflowid' => backup::VAR_PARENTID));
+            $post->set_source_table('moodleoverflow_posts', ['discussion' => backup::VAR_PARENTID], 'id ASC');
+            $rating->set_source_table('moodleoverflow_ratings', ['postid' => backup::VAR_PARENTID]);
+            $discussionsub->set_source_table('moodleoverflow_discuss_subs', ['discussion' => backup::VAR_PARENTID]);
+            $subscription->set_source_table('moodleoverflow_subscriptions', ['moodleoverflow' => backup::VAR_PARENTID]);
+            $read->set_source_table('moodleoverflow_read', ['moodleoverflowid' => backup::VAR_PARENTID]);
+            $track->set_source_table('moodleoverflow_tracking', ['moodleoverflowid' => backup::VAR_PARENTID]);
         }
 
         // Define id annotations.

--- a/backup/moodle2/restore_moodleoverflow_activity_task.class.php
+++ b/backup/moodle2/restore_moodleoverflow_activity_task.class.php
@@ -59,10 +59,10 @@ class restore_moodleoverflow_activity_task extends restore_activity_task {
      * processed by the link decoder
      */
     public static function define_decode_contents() {
-        $contents = array();
+        $contents = [];
 
-        $contents[] = new restore_decode_content('moodleoverflow', array('intro'), 'moodleoverflow');
-        $contents[] = new restore_decode_content('moodleoverflow_posts', array('message'), 'moodleoverflow_post');
+        $contents[] = new restore_decode_content('moodleoverflow', ['intro'], 'moodleoverflow');
+        $contents[] = new restore_decode_content('moodleoverflow_posts', ['message'], 'moodleoverflow_post');
 
         return $contents;
     }
@@ -72,7 +72,7 @@ class restore_moodleoverflow_activity_task extends restore_activity_task {
      * to the activity to be executed by the link decoder
      */
     public static function define_decode_rules() {
-        $rules = array();
+        $rules = [];
 
         $rules[] = new restore_decode_rule('MOODLEOVERFLOWVIEWBYID', '/mod/moodleoverflow/view.php?id=$1', 'course_module');
         $rules[] = new restore_decode_rule('MOODLEOVERFLOWINDEX', '/mod/moodleoverflow/index.php?id=$1', 'course');
@@ -85,9 +85,9 @@ class restore_moodleoverflow_activity_task extends restore_activity_task {
         // Link to discussion with parent and with anchor posts.
         $rules[] = new restore_decode_rule('MOODLEOVERFLOWDISCUSSIONVIEWPARENT',
             '/mod/moodleoverflow/discussion.php?d=$1&parent=$2',
-            array('moodleoverflow_discussion', 'moodleoverflow_post'));
+            ['moodleoverflow_discussion', 'moodleoverflow_post']);
         $rules[] = new restore_decode_rule('MOODLEOVERFLOWDISCUSSIONVIEWINSIDE', '/mod/moodleoverflow/discussion.php?d=$1#$2',
-            array('moodleoverflow_discussion', 'moodleoverflow_post'));
+            ['moodleoverflow_discussion', 'moodleoverflow_post']);
 
         return $rules;
 
@@ -100,7 +100,7 @@ class restore_moodleoverflow_activity_task extends restore_activity_task {
      * of { restore_log_rule} objects
      */
     public static function define_restore_log_rules() {
-        $rules = array();
+        $rules = [];
 
         $rules[] = new restore_log_rule('moodleoverflow', 'add',
             'view.php?id={course_module}', '{moodleoverflow}');
@@ -160,7 +160,7 @@ class restore_moodleoverflow_activity_task extends restore_activity_task {
      * activity level. All them are rules not linked to any module instance (cmid = 0)
      */
     public static function define_restore_log_rules_for_course() {
-        $rules = array();
+        $rules = [];
 
         $rules[] = new restore_log_rule('moodleoverflow', 'view all', 'index.php?id={course}', null);
 

--- a/backup/moodle2/restore_moodleoverflow_stepslib.php
+++ b/backup/moodle2/restore_moodleoverflow_stepslib.php
@@ -40,7 +40,7 @@ class restore_moodleoverflow_activity_structure_step extends restore_activity_st
      */
     protected function define_structure() {
 
-        $paths = array();
+        $paths = [];
         $userinfo = $this->get_setting_value('userinfo');
 
         $paths[] = new restore_path_element('moodleoverflow', '/activity/moodleoverflow');
@@ -138,7 +138,7 @@ class restore_moodleoverflow_activity_structure_step extends restore_activity_st
 
         // If !post->parent, it's the 1st post. Set it in discussion.
         if (empty($data->parent)) {
-            $DB->set_field('moodleoverflow_discussions', 'firstpost', $newitemid, array('id' => $data->discussion));
+            $DB->set_field('moodleoverflow_discussions', 'firstpost', $newitemid, ['id' => $data->discussion]);
         }
     }
 

--- a/classes/anonymous.php
+++ b/classes/anonymous.php
@@ -87,7 +87,7 @@ class anonymous {
         if ($moodleoverflow->anonymous == self::QUESTION_ANONYMOUS) {
             return [
                 $DB->get_field('moodleoverflow_posts', 'userid',
-                    ['parent' => 0, 'discussion' => $discussionid]) => get_string('questioner', 'mod_moodleoverflow')
+                    ['parent' => 0, 'discussion' => $discussionid]) => get_string('questioner', 'mod_moodleoverflow'),
             ];
         }
 

--- a/classes/event/readtracking_disabled.php
+++ b/classes/event/readtracking_disabled.php
@@ -74,6 +74,6 @@ class readtracking_disabled extends \core\event\base {
      * @return \moodle_url
      */
     public function get_url() {
-        return new \moodle_url('/mod/moodleoverflow/view.php', array('m' => $this->other['moodleoverflowid']));
+        return new \moodle_url('/mod/moodleoverflow/view.php', ['m' => $this->other['moodleoverflowid']]);
     }
 }

--- a/classes/event/readtracking_enabled.php
+++ b/classes/event/readtracking_enabled.php
@@ -74,6 +74,6 @@ class readtracking_enabled extends \core\event\base {
      * @return \moodle_url
      */
     public function get_url() {
-        return new \moodle_url('/mod/moodleoverflow/view.php', array('m' => $this->other['moodleoverflowid']));
+        return new \moodle_url('/mod/moodleoverflow/view.php', ['m' => $this->other['moodleoverflowid']]);
     }
 }

--- a/classes/manager/mail_manager.php
+++ b/classes/manager/mail_manager.php
@@ -1,0 +1,623 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Moodleoverflow mail manager.
+ *
+ * @package   mod_moodleoverflow
+ * @copyright 2023 Nina Herrmann
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_moodleoverflow\manager;
+
+use context_course;
+use context_module;
+use core_php_time_limit;
+use mod_moodleoverflow\anonymous;
+use mod_moodleoverflow\output\moodleoverflow_email;
+use mod_moodleoverflow\subscriptions;
+use stdClass;
+
+/**
+ * Moodleoverflow mail manager.
+ *
+ * @package   mod_moodleoverflow
+ * @copyright 2023 Nina Herrmann
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mail_manager {
+    // Mailing state constants.
+    /**
+     * Mail is pending.
+     */
+    const MOODLEOVERFLOW_MAILED_PENDING = 0;
+    /**
+     * Sucessfully send.
+     */
+    const MOODLEOVERFLOW_MAILED_SUCCESS = 1;
+    /**
+     * Error occurred.
+     */
+    const MOODLEOVERFLOW_MAILED_ERROR = 2;
+    /**
+     * Mail successfully reviewed.
+     */
+    const MOODLEOVERFLOW_MAILED_REVIEW_SUCCESS = 3;
+
+    /**
+     * Sends mail notifications about new posts.
+     *
+     * @return bool
+     */
+    public static function moodleoverflow_send_mails(): bool {
+        global $DB, $CFG, $PAGE;
+
+        // Get the course object of the top level site.
+        $site = get_site();
+
+        // Get the main renderers.
+        $htmlout = $PAGE->get_renderer('mod_moodleoverflow', 'email', 'htmlemail');
+        $textout = $PAGE->get_renderer('mod_moodleoverflow', 'email', 'textemail');
+
+        // Initiate the arrays that are saving the users that are subscribed to posts that needs sending.
+        $users = [];
+
+        // Status arrays.
+        $mailcount = [];
+        $errorcount = [];
+
+        // Cache arrays.
+        $discussions = [];
+        $moodleoverflows = [];
+        $courses = [];
+        $coursemodules = [];
+        $subscribedusers = [];
+
+        // Posts older than x days will not be mailed.
+        // This will avoid problems with the cron not ran for a long time.
+        $timenow = time();
+        $endtime = $timenow - get_config('moodleoverflow', 'maxeditingtime');
+        $starttime = $endtime - (get_config('moodleoverflow', 'maxmailingtime') * 60 * 60);
+
+        // Retrieve all unmailed posts.
+        $posts = self::moodleoverflow_get_unmailed_posts($starttime, $endtime);
+        if ($posts) {
+            // Mark those posts as mailed.
+            if (!self::moodleoverflow_mark_old_posts_as_mailed($endtime)) {
+                mtrace('Errors occurred while trying to mark some posts as being mailed.');
+                return false;
+            }
+
+            // Loop through all posts to be mailed.
+            foreach ($posts as $postid => $post) {
+                self::check_post($post, $mailcount, $users, $discussions, $errorcount, $posts, $postid,
+                   $moodleoverflows, $courses, $coursemodules);
+            }
+        }
+
+        // Send mails to the users with information about the posts.
+        if ($users && $posts) {
+            // Send one mail to every user.
+            foreach ($users as $userto) {
+                // Terminate if the process takes more time then two minutes.
+                core_php_time_limit::raise(120);
+
+                // Tracing information.
+                mtrace('Processing user ' . $userto->id);
+                // Initiate the user caches to save memory.
+                $userto = clone($userto);
+                $userto->ciewfullnames = [];
+                $userto->canpost = [];
+                $userto->markposts = [];
+
+                // Cache the capabilities of the user.
+                cron_setup_user($userto);
+
+                // Reset the caches.
+                foreach ($coursemodules as $moodleoverflowid => $unused) {
+                    $coursemodules[$moodleoverflowid]->cache = new stdClass();
+                    $coursemodules[$moodleoverflowid]->cache->caps = [];
+                    unset($coursemodules[$moodleoverflowid]->uservisible);
+                }
+
+                // Loop through all posts of this users.
+                foreach ($posts as $post) {
+
+                    self::send_post($userto, $post, $coursemodules, $errorcount,
+                        $discussions, $moodleoverflows, $courses, $mailcount, $users, $site, $textout, $htmlout);
+                }
+
+                // Release the memory.
+                unset($userto);
+            }
+        }
+
+        // Check for all posts whether errors occurred.
+        if ($posts) {
+
+            // Loop through all posts.
+            foreach ($posts as $post) {
+
+                // Tracing information.
+                mtrace($mailcount[$post->id] . " users were sent post $post->id");
+
+                // Mark the posts with errors in the database.
+                if ($errorcount[$post->id]) {
+                    $DB->set_field('moodleoverflow_posts', 'mailed', self::MOODLEOVERFLOW_MAILED_ERROR, ['id' => $post->id]);
+                }
+            }
+        }
+
+        // The task was completed.
+        return true;
+    }
+
+    /**
+     * Returns a list of all posts that have not been mailed yet.
+     *
+     * @param int $starttime posts created after this time
+     * @param int $endtime   posts created before this time
+     *
+     * @return array
+     */
+    public static function moodleoverflow_get_unmailed_posts($starttime, $endtime) {
+        global $DB;
+
+        // Set params for the sql query.
+        $params = [];
+        $params['ptimestart'] = $starttime;
+        $params['ptimeend'] = $endtime;
+
+        $pendingmail = self::MOODLEOVERFLOW_MAILED_PENDING;
+        $reviewsent = self::MOODLEOVERFLOW_MAILED_REVIEW_SUCCESS;
+
+        // Retrieve the records.
+        $sql = "SELECT p.*, d.course, d.moodleoverflow
+            FROM {moodleoverflow_posts} p
+            JOIN {moodleoverflow_discussions} d ON d.id = p.discussion
+            WHERE p.mailed IN ($pendingmail, $reviewsent) AND p.reviewed = 1
+            AND COALESCE(p.timereviewed, p.created) >= :ptimestart AND p.created < :ptimeend
+            ORDER BY p.modified ASC";
+
+        return $DB->get_records_sql($sql, $params);
+    }
+
+    /**
+     * Marks posts before a certain time as being mailed already.
+     *
+     * @param int $endtime
+     *
+     * @return bool
+     */
+    public static function moodleoverflow_mark_old_posts_as_mailed($endtime) {
+        global $DB;
+
+        // Get the current timestamp.
+        $now = time();
+
+        // Define variables for the sql query.
+        $params = [];
+        $params['mailedsuccess'] = self::MOODLEOVERFLOW_MAILED_SUCCESS;
+        $params['mailedreviewsent'] = self::MOODLEOVERFLOW_MAILED_REVIEW_SUCCESS;
+        $params['now'] = $now;
+        $params['endtime'] = $endtime;
+        $params['mailedpending'] = self::MOODLEOVERFLOW_MAILED_PENDING;
+
+        // Define the sql query.
+        $sql = "UPDATE {moodleoverflow_posts}
+            SET mailed = :mailedsuccess
+            WHERE (created < :endtime) AND mailed IN (:mailedpending, :mailedreviewsent) AND reviewed = 1";
+
+        return $DB->execute($sql, $params);
+
+    }
+    /**
+     * Removes unnecessary information from the user records for the mail generation.
+     *
+     * @param stdClass $user
+     */
+    public static function moodleoverflow_minimise_user_record(stdClass $user) {
+
+        // Remove all information for the mail generation that are not needed.
+        unset($user->institution);
+        unset($user->department);
+        unset($user->address);
+        unset($user->city);
+        unset($user->url);
+        unset($user->currentlogin);
+        unset($user->description);
+        unset($user->descriptionformat);
+    }
+
+    /**
+     * Check for a single post if the mail should be send. This includes:
+     * 1) Does a) the moodleoverflow
+     *         b) moodleoverflow discussion
+     *         c) course module
+     *          still exists?
+     * 2) Is the user subscriped?
+     * @param stdClass $post
+     * @param array $mailcount
+     * @param array $users
+     * @param array $discussions
+     * @param array $errorcount
+     * @param array $posts
+     * @param int $postid
+     * @param array $moodleoverflows
+     * @param array $courses
+     * @param array $coursemodules
+     * @return void
+     * @throws \coding_exception
+     * @throws \dml_exception
+     */
+    private static function check_post($post, array &$mailcount, array &$users, array &$discussions, array &$errorcount,
+                                       array &$posts, int $postid, array &$moodleoverflows, array &$courses,
+                                       array &$coursemodules) {
+        global $DB;
+        // Check the cache if the discussion exists.
+        $discussionid = $post->discussion;
+        if (!isset($discussions[$discussionid])) {
+            // Retrieve the discussion from the database.
+            $discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $post->discussion]);
+
+            // If there is a record, update the cache. Else ignore the post.
+            if ($discussion) {
+                $discussions[$discussionid] = $discussion;
+                subscriptions::fill_subscription_cache($discussion->moodleoverflow);
+                subscriptions::fill_discussion_subscription_cache($discussion->moodleoverflow);
+            } else {
+                mtrace('Could not find discussion ' . $discussionid);
+                unset($posts[$postid]);
+                return;
+            }
+        }
+
+        // Retrieve the connected moodleoverflow instance from the database.
+        $moodleoverflowid = $discussions[$discussionid]->moodleoverflow;
+        if (!isset($moodleoverflows[$moodleoverflowid])) {
+
+            // Retrieve the record from the database and update the cache.
+            $moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflowid]);
+            if ($moodleoverflow) {
+                $moodleoverflows[$moodleoverflowid] = $moodleoverflow;
+            } else {
+                mtrace('Could not find moodleoverflow ' . $moodleoverflowid);
+                unset($posts[$postid]);
+                return;
+            }
+        }
+
+        // Retrieve the connected courses from the database.
+        $courseid = $moodleoverflows[$moodleoverflowid]->course;
+        if (!isset($courses[$courseid])) {
+
+            // Retrieve the record from the database and update the cache.
+            $course = $DB->get_record('course', ['id' => $courseid]);
+            if ($course) {
+                $courses[$courseid] = $course;
+            } else {
+                mtrace('Could not find course ' . $courseid);
+                unset($posts[$postid]);
+                return;
+            }
+        }
+
+        // Retrieve the connected course modules from the database.
+        if (!isset($coursemodules[$moodleoverflowid])) {
+
+            // Retrieve the coursemodule and update the cache.
+            $cm = get_coursemodule_from_instance('moodleoverflow', $moodleoverflowid, $courseid);
+            if ($cm) {
+                $coursemodules[$moodleoverflowid] = $cm;
+            } else {
+                mtrace('Could not find course module for moodleoverflow ' . $moodleoverflowid);
+                unset($posts[$postid]);
+                return;
+            }
+        }
+
+        // Cache subscribed users of each moodleoverflow.
+        if (!isset($subscribedusers[$moodleoverflowid])) {
+
+            // Retrieve the context module.
+            $modulecontext = context_module::instance($coursemodules[$moodleoverflowid]->id);
+
+            // Retrieve all subscribed users.
+            $mid = $moodleoverflows[$moodleoverflowid];
+            $subusers = subscriptions::get_subscribed_users($mid, $modulecontext, 'u.*', true);
+            if ($subusers) {
+                // Loop through all subscribed users.
+                foreach ($subusers as $postuser) {
+                    // Save the user into the cache.
+                    $subscribedusers[$moodleoverflowid][$postuser->id] = $postuser->id;
+                    self::moodleoverflow_minimise_user_record($postuser);
+                    self::moodleoverflow_minimise_user_record($postuser);
+                    $users[$postuser->id] = $postuser;
+                }
+
+                // Release the memory.
+                unset($subusers);
+                unset($postuser);
+            }
+        }
+
+        // Initiate the count of the mails send and errors.
+        $mailcount[$postid] = 0;
+        $errorcount[$postid] = 0;
+    }
+
+    /**
+     * Send the Mail with information of the post depending on theinformation available.
+     * E.g. anonymous post do not include names, users who want resumes do not get single mails.
+     * @param stdClass $userto
+     * @param stdClass $post
+     * @param array $coursemodules
+     * @param array $errorcount
+     * @param array $discussions
+     * @param array $moodleoverflows
+     * @param array $courses
+     * @param array $mailcount
+     * @param array $users
+     * @param stdClass $site
+     * @param stdClass $textout
+     * @param stdClass $htmlout
+     * @return void
+     * @throws \coding_exception
+     * @throws \dml_exception
+     * @throws \moodle_exception
+     */
+    private static function send_post($userto, $post, array &$coursemodules, array &$errorcount,
+                                      array &$discussions, array &$moodleoverflows, array &$courses, array &$mailcount,
+                                      array &$users, $site, $textout, $htmlout) {
+        global $DB, $CFG;
+
+        // Initiate variables for the post.
+        $discussion = $discussions[$post->discussion];
+        $moodleoverflow = $moodleoverflows[$discussion->moodleoverflow];
+        $course = $courses[$moodleoverflow->course];
+        $cm             =& $coursemodules[$moodleoverflow->id];
+        $modulecontext = context_module::instance($cm->id);
+
+        // Check if user wants a resume.
+        // in this case: make a new dataset in "moodleoverflow_mail_info" to save the posts data.
+        // Dataset from moodleoverflow_mail_info will be send later in a mail.
+        $usermailsetting = $userto->maildigest;
+        if ($usermailsetting != 0) {
+            $dataobject = new stdClass();
+            $dataobject->userid = $userto->id;
+            $dataobject->courseid = $course->id;
+            $dataobject->forumid = $moodleoverflow->id;
+            $dataobject->forumdiscussionid = $discussion->id;
+            $record = $DB->get_record('moodleoverflow_mail_info',
+                ['userid' => $dataobject->userid,
+                    'courseid' => $dataobject->courseid,
+                    'forumid' => $dataobject->forumid,
+                    'forumdiscussionid' => $dataobject->forumdiscussionid],
+                'numberofposts, id');
+            if (is_object($record)) {
+                $dataset = $record;
+                $dataobject->numberofposts = $dataset->numberofposts + 1;
+                $dataobject->id = $dataset->id;
+                $DB->update_record('moodleoverflow_mail_info', $dataobject);
+            } else {
+                $dataobject->numberofposts = 1;
+                $DB->insert_record('moodleoverflow_mail_info', $dataobject);
+            }
+            return;
+        }
+
+        // Check whether the user is subscribed.
+        if (!isset($subscribedusers[$moodleoverflow->id][$userto->id])) {
+            return;
+        }
+
+        // Check whether the user is subscribed to the discussion.
+        $iscm = $coursemodules[$moodleoverflow->id];
+        $uid = $userto->id;
+        $did = $post->discussion;
+        $issubscribed = subscriptions::is_subscribed($uid, $moodleoverflow, $modulecontext, $did);
+        if (!$issubscribed) {
+            return;
+        }
+
+        // Check whether the user unsubscribed to the discussion after it was created.
+        $subnow = subscriptions::fetch_discussion_subscription($moodleoverflow->id, $userto->id);
+        if ($subnow && isset($subnow[$post->discussion]) && ($subnow[$post->discussion] > $post->created)) {
+            return;
+        }
+
+        if (anonymous::is_post_anonymous($discussion, $moodleoverflow, $post->userid)) {
+            $userfrom = \core_user::get_noreply_user();
+        } else {
+            // Check whether the sending user is cached already.
+            if (array_key_exists($post->userid, $users)) {
+                $userfrom = $users[$post->userid];
+            } else {
+                // We dont know the the user yet.
+
+                // Retrieve the user from the database.
+                $userfrom = $DB->get_record('user', ['id' => $post->userid]);
+                if ($userfrom) {
+                    self::moodleoverflow_minimise_user_record($userfrom);
+                } else {
+                    $uid = $post->userid;
+                    $pid = $post->id;
+                    mtrace('Could not find user ' . $uid . ', author of post ' . $pid . '. Unable to send message.');
+                    return;
+                }
+            }
+        }
+
+        // Setup roles and languages.
+        cron_setup_user($userto, $course);
+
+        // Cache the users capability to view full names.
+        if (!isset($userto->viewfullnames[$moodleoverflow->id])) {
+
+            // Find the context module.
+            $modulecontext = context_module::instance($cm->id);
+
+            // Check the users capabilities.
+            $userto->viewfullnames[$moodleoverflow->id] = has_capability('moodle/site:viewfullnames', $modulecontext);
+        }
+
+        // Cache the users capability to post in the discussion.
+        if (!isset($userto->canpost[$discussion->id])) {
+
+            // Find the context module.
+            $modulecontext = context_module::instance($cm->id);
+
+            // Check the users capabilities.
+            $canpost = moodleoverflow_user_can_post($modulecontext, $post, $userto->id);
+            $userto->canpost[$discussion->id] = $canpost;
+        }
+
+        // Make sure the current user is allowed to see the post.
+        if (!moodleoverflow_user_can_see_post($moodleoverflow, $discussion, $post, $cm)) {
+            mtrace('User ' . $userto->id . ' can not see ' . $post->id . '. Not sending message.');
+            return;
+        }
+
+        // Sent the email.
+
+        // Preapare to actually send the post now. Build up the content.
+        $cleanname = str_replace('"', "'", strip_tags(format_string($moodleoverflow->name)));
+        $coursecontext = context_course::instance($course->id);
+        $shortname = format_string($course->shortname, true, ['context' => $coursecontext]);
+
+        // Define a header to make mails easier to track.
+        $emailmessageid = generate_email_messageid('moodlemoodleoverflow' . $moodleoverflow->id);
+        $userfrom->customheaders = [
+            'List-Id: "' . $cleanname . '" ' . $emailmessageid,
+            'List-Help: ' . $CFG->wwwroot . '/mod/moodleoverflow/view.php?m=' . $moodleoverflow->id,
+            'Message-ID: ' . generate_email_messageid(hash('sha256', $post->id . 'to' . $userto->id)),
+            'X-Course-Id: ' . $course->id,
+            'X-Course-Name: ' . format_string($course->fullname, true),
+
+            // Headers to help prevent auto-responders.
+            'Precedence: Bulk',
+            'X-Auto-Response-Suppress: All',
+            'Auto-Submitted: auto-generated',
+        ];
+
+        // Cache the users capabilities.
+        if (!isset($userto->canpost[$discussion->id])) {
+            $canreply = moodleoverflow_user_can_post($modulecontext, $post, $userto->id);
+        } else {
+            $canreply = $userto->canpost[$discussion->id];
+        }
+
+        // Format the data.
+        $data = new moodleoverflow_email(
+            $course,
+            $cm,
+            $moodleoverflow,
+            $discussion,
+            $post,
+            $userfrom,
+            $userto,
+            $canreply
+        );
+
+        // Retrieve the unsubscribe-link.
+        $userfrom->customheaders[] = sprintf('List-Unsubscribe: <%s>', $data->get_unsubscribediscussionlink());
+
+        // Check the capabilities to view full names.
+        if (!isset($userto->viewfullnames[$moodleoverflow->id])) {
+            $data->viewfullnames = has_capability('moodle/site:viewfullnames', $modulecontext, $userto->id);
+        } else {
+            $data->viewfullnames = $userto->viewfullnames[$moodleoverflow->id];
+        }
+
+        // Retrieve needed variables for the mail.
+        $var = new stdClass();
+        $var->subject = $data->get_subject();
+        $var->moodleoverflowname = $cleanname;
+        $var->sitefullname = format_string($site->fullname);
+        $var->siteshortname = format_string($site->shortname);
+        $var->courseidnumber = $data->get_courseidnumber();
+        $var->coursefullname = $data->get_coursefullname();
+        $var->courseshortname = $data->get_coursename();
+        $postsubject = html_to_text(get_string('postmailsubject', 'moodleoverflow', $var), 0);
+        $rootid = generate_email_messageid(hash('sha256', $discussion->firstpost . 'to' . $userto->id));
+
+        // Check whether the post is a reply.
+        if ($post->parent) {
+
+            // Add a reply header.
+            $parentid = generate_email_messageid(hash('sha256', $post->parent . 'to' . $userto->id));
+            $userfrom->customheaders[] = "In-Reply-To: $parentid";
+
+            // Comments need a reference to the starting post as well.
+            if ($post->parent != $discussion->firstpost) {
+                $userfrom->customheaders[] = "References: $rootid $parentid";
+            } else {
+                $userfrom->customheaders[] = "References: $parentid";
+            }
+        }
+
+        // Send the post now.
+        mtrace('Sending ', '');
+
+        // Create the message event.
+        $eventdata = new \core\message\message();
+        $eventdata->courseid = $course->id;
+        $eventdata->component = 'mod_moodleoverflow';
+        $eventdata->name = 'posts';
+        $eventdata->userfrom = $userfrom;
+        $eventdata->userto = $userto;
+        $eventdata->subject = $postsubject;
+        $eventdata->fullmessage = $textout->render($data);
+        $eventdata->fullmessageformat = FORMAT_PLAIN;
+        $eventdata->fullmessagehtml = $htmlout->render($data);
+        $eventdata->notification = 1;
+
+        // Initiate another message array.
+        $small = new stdClass();
+        $small->user = fullname($userfrom);
+        $formatedstring = format_string($moodleoverflow->name, true);
+        $small->moodleoverflowname = "$shortname: " . $formatedstring . ": " . $discussion->name;
+        $small->message = $post->message;
+
+        // Make sure the language is correct.
+        $usertol = $userto->lang;
+        $eventdata->smallmessage = get_string_manager()->get_string('smallmessage', 'moodleoverflow', $small, $usertol);
+
+        // Generate the url to view the post.
+        $url = '/mod/moodleoverflow/discussion.php';
+        $params = ['d' => $discussion->id];
+        $contexturl = new moodle_url($url, $params, 'p' . $post->id);
+        $eventdata->contexturl = $contexturl->out();
+        $eventdata->contexturlname = $discussion->name;
+
+        // Actually send the message.
+        $mailsent = message_send($eventdata);
+
+        // Check whether the sending failed.
+        if (!$mailsent) {
+            mtrace('Error: mod/moodleoverflow/classes/task/send_mail.php execute(): ' .
+                "Could not send out mail for id $post->id to user $userto->id ($userto->email) .. not trying again.");
+            $errorcount[$post->id]++;
+        } else {
+            $mailcount[$post->id]++;
+        }
+
+        // Tracing message.
+        mtrace('post ' . $post->id . ': ' . $discussion->name);
+    }
+
+}

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -44,7 +44,7 @@ class mod_moodleoverflow_observer {
         if ($cp->lastenrol) {
 
             // Get the moodleoverflow instances from which the user was unenrolled from.
-            $moodleoverflows = $DB->get_records('moodleoverflow', array('course' => $cp->courseid), '', 'id');
+            $moodleoverflows = $DB->get_records('moodleoverflow', ['course' => $cp->courseid], '', 'id');
 
             // Do not continue if there are no connected moodleoverflow instances.
             if (!$moodleoverflows) {
@@ -93,9 +93,9 @@ class mod_moodleoverflow_observer {
                   JOIN {modules} mo ON (mo.id = cm.module)
              LEFT JOIN {moodleoverflow_subscriptions} ms ON (ms.moodleoverflow = m.id AND ms.userid = :userid)
                  WHERE m.course = :courseid AND m.forcesubscribe = :initial AND mo.name = 'moodleoverflow' AND ms.id IS NULL";
-        $params = array('courseid' => $context->instanceid,
+        $params = ['courseid' => $context->instanceid,
                                  'userid' => $userid,
-                                 'initial' => MOODLEOVERFLOW_INITIALSUBSCRIBE);
+                                 'initial' => MOODLEOVERFLOW_INITIALSUBSCRIBE];
         $moodleoverflows = $DB->get_records_sql($sql, $params);
 
         // Loop through all moodleoverflows.
@@ -133,7 +133,7 @@ class mod_moodleoverflow_observer {
             require_once($CFG->dirroot . '/mod/moodleoverflow/lib.php');
 
             // Create a snapshot of the created moodleoverflow record.
-            $moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $event->other['instanceid']));
+            $moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $event->other['instanceid']]);
 
             // Trigger the function for a created moodleoverflow instance.
             moodleoverflow_instance_created($event->get_context(), $moodleoverflow);

--- a/classes/output/moodleoverflow_email.php
+++ b/classes/output/moodleoverflow_email.php
@@ -102,9 +102,9 @@ class moodleoverflow_email implements \renderable, \templatable {
      *
      * @var array $writablekeys
      */
-    protected $writablekeys = array(
+    protected $writablekeys = [
         'viewfullnames' => true,
-    );
+    ];
 
     /**
      * Builds a renderable moodleoverflow mail.
@@ -154,7 +154,7 @@ class moodleoverflow_email implements \renderable, \templatable {
      */
     protected function export_for_template_text(\mod_moodleoverflow_renderer $renderer) {
 
-        return array(
+        return [
             'id' => html_entity_decode($this->post->id, ENT_COMPAT),
             'coursename' => html_entity_decode($this->get_coursename(), ENT_COMPAT),
             'courselink' => html_entity_decode($this->get_courselink(), ENT_COMPAT),
@@ -180,7 +180,7 @@ class moodleoverflow_email implements \renderable, \templatable {
 
             // Format some components according to the renderer.
             'message' => html_entity_decode($renderer->format_message_text($this->cm, $this->post), ENT_COMPAT),
-        );
+        ];
     }
 
     /**
@@ -191,7 +191,7 @@ class moodleoverflow_email implements \renderable, \templatable {
      * @return stdClass Data ready for use in a mustache template
      */
     protected function export_for_template_html(\mod_moodleoverflow_renderer $renderer) {
-        return array(
+        return [
             'id' => $this->post->id,
             'coursename' => $this->get_coursename(),
             'courselink' => $this->get_courselink(),
@@ -217,7 +217,7 @@ class moodleoverflow_email implements \renderable, \templatable {
 
             // Format some components according to the renderer.
             'message' => $renderer->format_message_text($this->cm, $this->post),
-        );
+        ];
     }
 
     /**
@@ -263,7 +263,7 @@ class moodleoverflow_email implements \renderable, \templatable {
         $url = '/mod/moodleoverflow/subscribe.php';
 
         // Generate a link to unsubscribe from the discussion.
-        $link = new \moodle_url($url, array('id' => $id, 'd' => $d));
+        $link = new \moodle_url($url, ['id' => $id, 'd' => $d]);
 
         return $link->out(false);
     }
@@ -292,9 +292,9 @@ class moodleoverflow_email implements \renderable, \templatable {
      * @return string
      */
     public function get_coursefullname() {
-        return format_string($this->course->fullname, true, array(
+        return format_string($this->course->fullname, true, [
             'context' => \context_course::instance($this->course->id),
-        ));
+        ]);
     }
 
     /**
@@ -303,9 +303,9 @@ class moodleoverflow_email implements \renderable, \templatable {
      * @return string
      */
     public function get_coursename() {
-        return format_string($this->course->shortname, true, array(
+        return format_string($this->course->shortname, true, [
             'context' => \context_course::instance($this->course->id),
-        ));
+        ]);
     }
 
     /**
@@ -316,9 +316,9 @@ class moodleoverflow_email implements \renderable, \templatable {
     public function get_courselink() {
         $link = new \moodle_url(
         // Posts are viewed on the topic.
-            '/course/view.php', array(
+            '/course/view.php', [
                 'id' => $this->course->id,
-            )
+            ]
         );
 
         return $link->out(false);
@@ -420,9 +420,9 @@ class moodleoverflow_email implements \renderable, \templatable {
      */
     public function get_replylink() {
         return new \moodle_url(
-            '/mod/moodleoverflow/post.php', array(
+            '/mod/moodleoverflow/post.php', [
                 'reply' => $this->post->id,
-            )
+            ]
         );
     }
 
@@ -437,9 +437,9 @@ class moodleoverflow_email implements \renderable, \templatable {
             return null;
         }
         $link = new \moodle_url(
-            '/mod/moodleoverflow/subscribe.php', array(
+            '/mod/moodleoverflow/subscribe.php', [
                 'id' => $this->moodleoverflow->id,
-            )
+            ]
         );
 
         return $link->out(false);
@@ -465,10 +465,10 @@ class moodleoverflow_email implements \renderable, \templatable {
     protected function get_discussionurl() {
         return new \moodle_url(
         // Posts are viewed on the topic.
-            '/mod/moodleoverflow/discussion.php', array(
+            '/mod/moodleoverflow/discussion.php', [
                 // Within a discussion.
                 'd' => $this->discussion->id,
-            )
+            ]
         );
     }
 
@@ -491,9 +491,9 @@ class moodleoverflow_email implements \renderable, \templatable {
     public function get_moodleoverflowindexlink() {
         $link = new \moodle_url(
         // Posts are viewed on the topic.
-            '/mod/moodleoverflow/index.php', array(
+            '/mod/moodleoverflow/index.php', [
                 'id' => $this->course->id,
-            )
+            ]
         );
 
         return $link->out(false);
@@ -507,9 +507,9 @@ class moodleoverflow_email implements \renderable, \templatable {
     public function get_moodleoverflowviewlink() {
         $link = new \moodle_url(
         // Posts are viewed on the topic.
-            '/mod/moodleoverflow/view.php', array(
+            '/mod/moodleoverflow/view.php', [
                 'm' => $this->moodleoverflow->id,
-            )
+            ]
         );
 
         return $link->out(false);
@@ -526,10 +526,10 @@ class moodleoverflow_email implements \renderable, \templatable {
         }
 
         $link = new \moodle_url(
-            '/user/view.php', array(
+            '/user/view.php', [
                 'id' => $this->post->userid,
                 'course' => $this->course->id,
-            )
+            ]
         );
 
         return $link->out(false);
@@ -546,7 +546,7 @@ class moodleoverflow_email implements \renderable, \templatable {
             return '';
         }
 
-        return $OUTPUT->user_picture($this->author, array('courseid' => $this->course->id));
+        return $OUTPUT->user_picture($this->author, ['courseid' => $this->course->id]);
     }
 
     /**

--- a/classes/post_form.php
+++ b/classes/post_form.php
@@ -133,13 +133,13 @@ class mod_moodleoverflow_post_form extends moodleform {
         global $COURSE, $PAGE, $CFG;
         $maxbytes = get_user_max_upload_file_size($PAGE->context, $CFG->maxbytes, $COURSE->maxbytes, $moodleoverflow->maxbytes);
 
-        return array(
+        return [
             'subdirs' => 0,
             'maxbytes' => $maxbytes,
             'maxfiles' => $moodleoverflow->maxattachments,
             'accepted_types' => '*',
-            'return_types' => FILE_INTERNAL | FILE_CONTROLLED_LINK
-        );
+            'return_types' => FILE_INTERNAL | FILE_CONTROLLED_LINK,
+        ];
     }
 }
 

--- a/classes/privacy/data_export_helper.php
+++ b/classes/privacy/data_export_helper.php
@@ -22,7 +22,7 @@
  */
 namespace mod_moodleoverflow\privacy;
 use core_privacy\local\request\transform;
-use \core_privacy\local\request\writer;
+use core_privacy\local\request\writer;
 use mod_moodleoverflow\ratings;
 
 /**
@@ -78,7 +78,7 @@ class data_export_helper {
                 'name' => format_string($discussion->name, true),
                 'timemodified' => transform::datetime($discussion->timemodified),
                 'creator_was_you' => transform::yesno($discussion->userid == $userid),
-                'last_modifier_was_you' => transform::yesno($discussion->usermodified == $userid)
+                'last_modifier_was_you' => transform::yesno($discussion->usermodified == $userid),
             ];
             // Store the discussion content.
             writer::with_context($context)->export_data(
@@ -164,7 +164,7 @@ class data_export_helper {
         $params = [
             'discussionid' => $discussionid,
             'readuserid' => $userid,
-            'ratinguserid' => $userid
+            'ratinguserid' => $userid,
         ];
 
         // Keep track of the forums which have data.
@@ -237,7 +237,7 @@ class data_export_helper {
         $postdata = (object) [
             'created' => transform::datetime($post->created),
             'modified' => transform::datetime($post->modified),
-            'author_was_you' => transform::yesno($post->userid == $userid)
+            'author_was_you' => transform::yesno($post->userid == $userid),
         ];
         $postdata->message = writer::with_context($context)->rewrite_pluginfile_urls(
             $postarea, 'mod_moodleoverflow', 'attachment', $post->id, $post->message);
@@ -285,11 +285,11 @@ class data_export_helper {
             'userid' => $userid,
             'postid' => $postid,
         ]);
-        $userratings = array();
+        $userratings = [];
         foreach ($ownratings as $rating) {
             $userratings[] = (object) [
                 'firstrated' => $rating->firstrated,
-                'rating' => $rating->rating
+                'rating' => $rating->rating,
             ];
         }
 
@@ -298,7 +298,7 @@ class data_export_helper {
                 'downvotes' => $ratingpost->downvotes,
                 'upvotes' => $ratingpost->upvotes,
                 'was_rated_as_helpful' => transform::yesno($ratingpost->ishelpful),
-                'was_rated_as_solved' => transform::yesno($ratingpost->issolved)
+                'was_rated_as_solved' => transform::yesno($ratingpost->issolved),
             ];
         }
         $ratingdata['your_rating'] = (object) $userratings;

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -25,12 +25,12 @@
 namespace mod_moodleoverflow\privacy;
 
 use core_privacy\local\request\approved_userlist;
-use \core_privacy\local\request\userlist;
+use core_privacy\local\request\userlist;
 use core_privacy\local\metadata\collection;
 use core_privacy\local\request\approved_contextlist;
 use core_privacy\local\request\contextlist;
 use core_privacy\local\request\writer;
-use \core_privacy\local\request\helper as request_helper;
+use core_privacy\local\request\helper as request_helper;
 
 /**
  * Privacy Subsystem for mod_moodleoverflow implementing provider.
@@ -56,7 +56,7 @@ class provider implements
                 'name' => 'privacy:metadata:moodleoverflow_discussions:name',
                 'userid' => 'privacy:metadata:moodleoverflow_discussions:userid',
                 'timemodified' => 'privacy:metadata:moodleoverflow_discussions:timemodified',
-                'usermodified' => 'privacy:metadata:moodleoverflow_discussions:usermodified'
+                'usermodified' => 'privacy:metadata:moodleoverflow_discussions:usermodified',
             ],
             'privacy:metadata:moodleoverflow_discussions');
 
@@ -67,7 +67,7 @@ class provider implements
                 'userid' => 'privacy:metadata:moodleoverflow_posts:userid',
                 'created' => 'privacy:metadata:moodleoverflow_posts:created',
                 'modified' => 'privacy:metadata:moodleoverflow_posts:modified',
-                'message' => 'privacy:metadata:moodleoverflow_posts:message'
+                'message' => 'privacy:metadata:moodleoverflow_posts:message',
             ],
             'privacy:metadata:moodleoverflow_posts');
 
@@ -77,14 +77,14 @@ class provider implements
                 'discussionid' => 'privacy:metadata:moodleoverflow_read:discussionid',
                 'postid' => 'privacy:metadata:moodleoverflow_read:postid',
                 'firstread' => 'privacy:metadata:moodleoverflow_read:firstread',
-                'lastread' => 'privacy:metadata:moodleoverflow_read:lastread'
+                'lastread' => 'privacy:metadata:moodleoverflow_read:lastread',
             ],
             'privacy:metadata:moodleoverflow_read');
 
         $collection->add_database_table('moodleoverflow_subscriptions',
             [
                 'userid' => 'privacy:metadata:moodleoverflow_subscriptions:userid',
-                'moodleoverflow' => 'privacy:metadata:moodleoverflow_subscriptions:moodleoverflow'
+                'moodleoverflow' => 'privacy:metadata:moodleoverflow_subscriptions:moodleoverflow',
             ],
             'privacy:metadata:moodleoverflow_subscriptions');
 
@@ -92,7 +92,7 @@ class provider implements
             [
                 'userid' => 'privacy:metadata:moodleoverflow_discuss_subs:userid',
                 'discussion' => 'privacy:metadata:moodleoverflow_discuss_subs:discussion',
-                'preference' => 'privacy:metadata:moodleoverflow_discuss_subs:preference'
+                'preference' => 'privacy:metadata:moodleoverflow_discuss_subs:preference',
             ],
             'privacy:metadata:moodleoverflow_discuss_subs');
 
@@ -102,14 +102,14 @@ class provider implements
                 'postid' => 'privacy:metadata:moodleoverflow_ratings:postid',
                 'rating' => 'privacy:metadata:moodleoverflow_ratings:rating',
                 'firstrated' => 'privacy:metadata:moodleoverflow_ratings:firstrated',
-                'lastchanged' => 'privacy:metadata:moodleoverflow_ratings:lastchanged'
+                'lastchanged' => 'privacy:metadata:moodleoverflow_ratings:lastchanged',
             ],
             'privacy:metadata:moodleoverflow_ratings');
 
         $collection->add_database_table('moodleoverflow_tracking',
             [
                 'userid' => 'privacy:metadata:moodleoverflow_tracking:userid',
-                'moodleoverflowid' => 'privacy:metadata:moodleoverflow_tracking:moodleoverflowid'
+                'moodleoverflowid' => 'privacy:metadata:moodleoverflow_tracking:moodleoverflowid',
             ],
             'privacy:metadata:moodleoverflow_tracking');
 
@@ -177,7 +177,7 @@ class provider implements
             'dsuserid' => $userid,
             'rauserid' => $userid,
             'tuserid' => $userid,
-            'guserid' => $userid
+            'guserid' => $userid,
         ];
 
         $contextlist = new \core_privacy\local\request\contextlist();
@@ -225,7 +225,7 @@ class provider implements
         $params = [
             'suserid' => $userid,
             'userid' => $userid,
-            'guserid' => $userid
+            'guserid' => $userid,
         ];
         $params += $contextparams;
 
@@ -346,7 +346,7 @@ class provider implements
             (SELECT id FROM {moodleoverflow_discussions} WHERE moodleoverflow = :forum)";
             $ratingparams = [
                 'forum' => $forum->id,
-                'userid' => $userid
+                'userid' => $userid,
             ];
             $DB->set_field_select('moodleoverflow_ratings', 'userid', 0, $ratingsql, $ratingparams);
 
@@ -355,7 +355,7 @@ class provider implements
             $postidsql = "SELECT p.id FROM {moodleoverflow_posts} p WHERE {$postsql}";
             $postparams = [
                 'forum' => $forum->id,
-                'userid' => $userid
+                'userid' => $userid,
             ];
 
             // Delete all files from the posts.

--- a/classes/ratings.php
+++ b/classes/ratings.php
@@ -228,9 +228,10 @@ class ratings {
     /**
      * Sort the answers of a discussion by their marks and votes.
      *
-     * @param object $posts all the posts from a discussion.
+     * @param array $posts all the posts from a discussion.
      */
     public static function moodleoverflow_sort_answers_by_ratings($posts) {
+
         // Create a copy that only has the answer posts and save the parent post.
         $answerposts = $posts;
         $parentpost = array_shift($answerposts);
@@ -847,4 +848,29 @@ class ratings {
         }
     }
 
+    private static function moodleoverflow_mergesort_post_by_votes(array &$posts, $low, $high): array {
+        $length = $high - $low;
+        if ($length <= 1) {
+            return $posts;
+        }
+        $mid = $low + (int) ($length / 2);
+
+        self::moodleoverflow_mergesort_post_by_votes($posts, $low, $mid);
+        self::moodleoverflow_mergesort_post_by_votes($posts, $mid + 1, $high);
+        return self::moodleoverflow_merge_posts($post, $low, $mid, $mid+1, $high);
+    }
+
+    private static function moodleoverflow_merge_posts(&$posts, $leftlow, $lefthigh, $rightlow, $righthigh) {
+        while ($leftlow <= $lefthigh && $rightlow <= $righthigh) {
+            // Sort after votesdifference, then sort after time created.
+            if ($posts[$leftlow]->votesdifference > $posts[$rightlow]->votesdifference) {
+                $leftlow++;
+            } else {
+                $value = $posts[$rightlow];
+                $index = $rightlow;
+
+                //Shift all the element
+            }
+        }
+    }
 }

--- a/classes/ratings.php
+++ b/classes/ratings.php
@@ -833,7 +833,7 @@ class ratings {
         $pivot = 0;
         if ($sortby == 'votesdifference') {
             $pivot = $posts[intval(($low + $high) / 2)]->votesdifference;
-        } else if ($sortby == 'modified'){
+        } else if ($sortby == 'modified') {
             $pivot = $posts[intval(($low + $high) / 2)]->modified;
         }
         do {
@@ -869,8 +869,8 @@ class ratings {
     }
 
     /**
-     * Helper function for moodleoverflow_sort_answer_by_rating. For posts that have the same mark and votesdifference, the posts are
-     * sorted by time modified
+     * Helper function for moodleoverflow_sort_answer_by_rating. For posts that have the same mark and votesdifference,
+     * the posts are sorted by time modified
      * @param array $posts  The array that will be sorted
      * @param int   $low    Startindex from where equal votes will be checked
      * @param int   $high   Endindex until where equal votes will be checked
@@ -881,10 +881,11 @@ class ratings {
             if ($posts[$low]->votesdifference == $posts[$low + 1]->votesdifference) {
                 $tempstartindex = $low;
                 $tempendindex = $tempstartindex + 1;
-                while (($tempendindex + 1 <= $high) && ($posts[$tempendindex]->votesdifference == $posts[$tempendindex + 1]->votesdifference)) {
+                while (($tempendindex + 1 <= $high) &&
+                      ($posts[$tempendindex]->votesdifference == $posts[$tempendindex + 1]->votesdifference)) {
                     $tempendindex++;
                 }
-                self::moodleoverflow_quicksort_posts($posts,$tempstartindex, $tempendindex, 'modified');
+                self::moodleoverflow_quicksort_posts($posts, $tempstartindex, $tempendindex, 'modified');
                 $low = $tempendindex + 1;
             } else {
                 $low++;

--- a/classes/ratings.php
+++ b/classes/ratings.php
@@ -228,10 +228,9 @@ class ratings {
     /**
      * Sort the answers of a discussion by their marks and votes.
      *
-     * @param array $posts all the posts from a discussion.
+     * @param object $posts all the posts from a discussion.
      */
     public static function moodleoverflow_sort_answers_by_ratings($posts) {
-
         // Create a copy that only has the answer posts and save the parent post.
         $answerposts = $posts;
         $parentpost = array_shift($answerposts);
@@ -848,29 +847,4 @@ class ratings {
         }
     }
 
-    private static function moodleoverflow_mergesort_post_by_votes(array &$posts, $low, $high): array {
-        $length = $high - $low;
-        if ($length <= 1) {
-            return $posts;
-        }
-        $mid = $low + (int) ($length / 2);
-
-        self::moodleoverflow_mergesort_post_by_votes($posts, $low, $mid);
-        self::moodleoverflow_mergesort_post_by_votes($posts, $mid + 1, $high);
-        return self::moodleoverflow_merge_posts($post, $low, $mid, $mid+1, $high);
-    }
-
-    private static function moodleoverflow_merge_posts(&$posts, $leftlow, $lefthigh, $rightlow, $righthigh) {
-        while ($leftlow <= $lefthigh && $rightlow <= $righthigh) {
-            // Sort after votesdifference, then sort after time created.
-            if ($posts[$leftlow]->votesdifference > $posts[$rightlow]->votesdifference) {
-                $leftlow++;
-            } else {
-                $value = $posts[$rightlow];
-                $index = $rightlow;
-
-                //Shift all the element
-            }
-        }
-    }
 }

--- a/classes/ratings.php
+++ b/classes/ratings.php
@@ -55,30 +55,30 @@ class ratings {
         }
 
         // Is the submitted rating valid?
-        $possibleratings = array(RATING_NEUTRAL, RATING_DOWNVOTE, RATING_UPVOTE, RATING_SOLVED,
+        $possibleratings = [RATING_NEUTRAL, RATING_DOWNVOTE, RATING_UPVOTE, RATING_SOLVED,
             RATING_HELPFUL, RATING_REMOVE_DOWNVOTE, RATING_REMOVE_UPVOTE,
-            RATING_REMOVE_SOLVED, RATING_REMOVE_HELPFUL);
+            RATING_REMOVE_SOLVED, RATING_REMOVE_HELPFUL];
         if (!in_array($rating, $possibleratings)) {
             throw new moodle_exception('invalidratingid', 'moodleoverflow');
         }
 
         // Get the related discussion.
-        if (!$post = $DB->get_record('moodleoverflow_posts', array('id' => $postid))) {
+        if (!$post = $DB->get_record('moodleoverflow_posts', ['id' => $postid])) {
             throw new moodle_exception('invalidparentpostid', 'moodleoverflow');
         }
 
         // Check if the post belongs to a discussion.
-        if (!$discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $post->discussion))) {
+        if (!$discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $post->discussion])) {
             throw new moodle_exception('notpartofdiscussion', 'moodleoverflow');
         }
 
         // Get the related course.
-        if (!$course = $DB->get_record('course', array('id' => $moodleoverflow->course))) {
+        if (!$course = $DB->get_record('course', ['id' => $moodleoverflow->course])) {
             throw new moodle_exception('invalidcourseid');
         }
 
         // Are multiple marks allowed?
-        $markssetting = $DB->get_record('moodleoverflow', array('id' => $moodleoverflow->id), 'allowmultiplemarks');
+        $markssetting = $DB->get_record('moodleoverflow', ['id' => $moodleoverflow->id], 'allowmultiplemarks');
         $multiplemarks = (bool) $markssetting->allowmultiplemarks;
 
         // Retrieve the contexts.
@@ -93,10 +93,10 @@ class ratings {
             if (!isguestuser() && !is_enrolled($coursecontext)) {
                 $SESSION->wantsurl = qualified_me();
                 $SESSION->enrolcancel = get_local_referer(false);
-                redirect(new \moodle_url('/enrol/index.php', array(
+                redirect(new \moodle_url('/enrol/index.php', [
                     'id' => $course->id,
-                    'returnurl' => '/mod/moodleoverflow/view.php?m' . $moodleoverflow->id
-                )), get_string('youneedtoenrol'));
+                    'returnurl' => '/mod/moodleoverflow/view.php?m' . $moodleoverflow->id,
+                ]), get_string('youneedtoenrol'));
             }
 
             // Notify the user, that he can not post a new discussion.
@@ -212,7 +212,7 @@ class ratings {
         }
 
         // Check the moodleoverflow instance.
-        if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $moodleoverflowid))) {
+        if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflowid])) {
             throw new moodle_exception('invalidmoodleoverflowid', 'moodleoverflow');
         }
 
@@ -349,7 +349,7 @@ class ratings {
 
         // Rearrange the indices and return the sorted posts.
 
-        $neworder = array();
+        $neworder = [];
         foreach ($sortedposts as $post) {
             $neworder[$post->id] = $post;
         }
@@ -393,7 +393,7 @@ class ratings {
         global $DB;
 
         // Retrieve the full post.
-        if (!$post = $DB->get_record('moodleoverflow_posts', array('id' => $postid))) {
+        if (!$post = $DB->get_record('moodleoverflow_posts', ['id' => $postid])) {
             throw new moodle_exception('postnotexist', 'moodleoverflow');
         }
 
@@ -454,10 +454,10 @@ class ratings {
         if ($teacher) {
 
             // Check if a teacher marked a solution as solved.
-            if ($DB->record_exists('moodleoverflow_ratings', array('discussionid' => $discussionid, 'rating' => 3))) {
+            if ($DB->record_exists('moodleoverflow_ratings', ['discussionid' => $discussionid, 'rating' => 3])) {
 
                 // Return the rating records.
-                return $DB->get_records('moodleoverflow_ratings', array('discussionid' => $discussionid, 'rating' => 3));
+                return $DB->get_records('moodleoverflow_ratings', ['discussionid' => $discussionid, 'rating' => 3]);
             }
 
             // The teacher has not marked the discussion as solved.
@@ -465,10 +465,10 @@ class ratings {
         }
 
         // Check if the topic starter marked a solution as helpful.
-        if ($DB->record_exists('moodleoverflow_ratings', array('discussionid' => $discussionid, 'rating' => 4))) {
+        if ($DB->record_exists('moodleoverflow_ratings', ['discussionid' => $discussionid, 'rating' => 4])) {
 
             // Return the rating records.
-            return $DB->get_records('moodleoverflow_ratings', array('discussionid' => $discussionid, 'rating' => 4));
+            return $DB->get_records('moodleoverflow_ratings', ['discussionid' => $discussionid, 'rating' => 4]);
         }
 
         // The topic starter has not marked a solution as helpful.
@@ -492,7 +492,7 @@ class ratings {
         }
 
         // Check the moodleoverflow instance.
-        if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $moodleoverflowid))) {
+        if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflowid])) {
             throw new moodle_exception('invalidmoodleoverflowid', 'moodleoverflow');
         }
 
@@ -514,11 +514,11 @@ class ratings {
 
             $sql .= "ORDER BY r.postid ASC";
 
-            $params = array($userid, $userid, $moodleoverflowid);
+            $params = [$userid, $userid, $moodleoverflowid];
             $records = $DB->get_records_sql($sql, $params);
 
             // Check if there are results.
-            $records = (isset($records)) ? $records : array();
+            $records = (isset($records)) ? $records : [];
 
             // Iterate through all ratings.
             foreach ($records as $record) {
@@ -557,7 +557,7 @@ class ratings {
         $sql = "SELECT COUNT(id) as amount
                 FROM {moodleoverflow_ratings}
                 WHERE userid = ? AND moodleoverflowid = ? AND (rating = 1 OR rating = 2)";
-        $params = array($userid, $moodleoverflowid);
+        $params = [$userid, $moodleoverflowid];
         $votes = $DB->get_record_sql($sql, $params);
 
         // Add reputation for the votes.
@@ -592,7 +592,7 @@ class ratings {
         $reputation = 0;
 
         // Check if the course exists.
-        if (!$course = $DB->get_record('course', array('id' => $courseid))) {
+        if (!$course = $DB->get_record('course', ['id' => $courseid])) {
             throw new moodle_exception('invalidcourseid');
         }
 
@@ -601,11 +601,11 @@ class ratings {
                   FROM {moodleoverflow}
                  WHERE course = ?
                    AND coursewidereputation = 1";
-        $params = array($course->id);
+        $params = [$course->id];
         $instances = $DB->get_records_sql($sql, $params);
 
         // Check if there are instances in this course.
-        $instances = (isset($instances)) ? $instances : array();
+        $instances = (isset($instances)) ? $instances : [];
 
         // Sum the reputation of each individual instance.
         foreach ($instances as $instance) {
@@ -629,7 +629,7 @@ class ratings {
         global $DB;
 
         // Initiate the array.
-        $rating = array();
+        $rating = [];
 
         // Get the normal rating.
         $sql = "SELECT *
@@ -711,16 +711,16 @@ class ratings {
         $oldrecord = self::moodleoverflow_check_old_rating($postid, $userid, $rating);
 
         // Trigger an event.
-        $params = array(
+        $params = [
             'objectid' => $oldrecord->id,
             'context' => $modulecontext,
-        );
+        ];
         $event = \mod_moodleoverflow\event\rating_deleted::create($params);
         $event->add_record_snapshot('moodleoverflow_ratings', $oldrecord);
         $event->trigger();
 
         // Remove the rating record.
-        return $DB->delete_records('moodleoverflow_ratings', array('id' => $oldrecord->id));
+        return $DB->delete_records('moodleoverflow_ratings', ['id' => $oldrecord->id]);
     }
 
     /**
@@ -752,10 +752,10 @@ class ratings {
         $recordid = $DB->insert_record('moodleoverflow_ratings', $record);
 
         // Trigger an event.
-        $params = array(
+        $params = [
             'objectid' => $recordid,
             'context' => $mod,
-        );
+        ];
         $event = \mod_moodleoverflow\event\rating_created::create($params);
         $event->trigger();
 
@@ -783,14 +783,14 @@ class ratings {
                  WHERE id = ?";
 
         // Trigger an event.
-        $params = array(
+        $params = [
             'objectid' => $ratingid,
             'context' => $modulecontext,
-        );
+        ];
         $event = \mod_moodleoverflow\event\rating_updated::create($params);
         $event->trigger();
 
-        return $DB->execute($sql, array($postid, $userid, $rating, time(), $ratingid));
+        return $DB->execute($sql, [$postid, $userid, $rating, time(), $ratingid]);
     }
 
     /**

--- a/classes/readtracking.php
+++ b/classes/readtracking.php
@@ -106,7 +106,7 @@ class readtracking {
 
         // Check the preferences of the user.
         $userpreference = $DB->get_record('moodleoverflow_tracking',
-            array('userid' => $user->id, 'moodleoverflowid' => $moodleoverflow->id));
+            ['userid' => $user->id, 'moodleoverflowid' => $moodleoverflow->id]);
 
         // Return the boolean.
         if (get_config('moodleoverflow', 'allowforcedreadtracking')) {
@@ -242,7 +242,7 @@ class readtracking {
         $cutoffdate = $now - (get_config('moodleoverflow', 'oldpostdays') * 24 * 3600);
 
         // Check for read records for this user an this post.
-        $oldrecord = $DB->get_record('moodleoverflow_read', array('postid' => $postid, 'userid' => $userid));
+        $oldrecord = $DB->get_record('moodleoverflow_read', ['postid' => $postid, 'userid' => $userid]);
         if (!$oldrecord) {
 
             // If there are no old records, create a new one.
@@ -252,7 +252,7 @@ class readtracking {
                         JOIN {moodleoverflow_discussions} d ON d.id = p.discussion
                   WHERE p.id = ? AND p.modified >= ?";
 
-            return $DB->execute($sql, array($userid, $now, $now, $postid, $cutoffdate));
+            return $DB->execute($sql, [$userid, $now, $now, $postid, $cutoffdate]);
         }
 
         // Else update the existing one.
@@ -260,7 +260,7 @@ class readtracking {
                    SET lastread = ?
                  WHERE userid = ? AND postid = ?";
 
-        return $DB->execute($sql, array($now, $userid, $userid));
+        return $DB->execute($sql, [$now, $userid, $userid]);
     }
 
     /**
@@ -278,7 +278,7 @@ class readtracking {
         global $DB;
 
         // Initiate variables.
-        $params = array();
+        $params = [];
         $select = '';
 
         // Create the sql-Statement depending on the submitted parameters.
@@ -351,7 +351,7 @@ class readtracking {
                 WHERE postid IN (SELECT p.id
                                  FROM {moodleoverflow_posts} p
                                  WHERE p.modified >= ? AND p.modified < ?)";
-        $DB->execute($sql, array($first, $cutoffdate));
+        $DB->execute($sql, [$first, $cutoffdate]);
     }
 
     /**
@@ -371,7 +371,7 @@ class readtracking {
         }
 
         // Check if the user already stopped to track the moodleoverflow.
-        $params = array('userid' => $userid, 'moodleoverflowid' => $moodleoverflowid);
+        $params = ['userid' => $userid, 'moodleoverflowid' => $moodleoverflowid];
         $isstopped = $DB->record_exists('moodleoverflow_tracking', $params);
 
         // Stop tracking the moodleoverflow if not already stopped.
@@ -410,7 +410,7 @@ class readtracking {
         }
 
         // Delete the tracking setting of this user for this moodleoverflow.
-        return $DB->delete_records('moodleoverflow_tracking', array('userid' => $userid, 'moodleoverflowid' => $moodleoverflowid));
+        return $DB->delete_records('moodleoverflow_tracking', ['userid' => $userid, 'moodleoverflowid' => $moodleoverflowid]);
     }
 
     /**
@@ -446,11 +446,11 @@ class readtracking {
                  WHERE m.course = ? $trackingsql";
 
         // Get all untracked moodleoverflows from the database.
-        $moodleoverflows = $DB->get_records_sql($sql, array($userid, $courseid, $userid));
+        $moodleoverflows = $DB->get_records_sql($sql, [$userid, $courseid, $userid]);
 
         // Check whether there are no untracked moodleoverflows.
         if (!$moodleoverflows) {
-            return array();
+            return [];
         }
 
         // Loop through all moodleoverflows.
@@ -491,7 +491,7 @@ class readtracking {
         $cutoffdate = $now - (get_config('moodleoverflow', 'oldpostdays') * 24 * 60 * 60);
 
         // Define a sql-query.
-        $params = array($USER->id, $cm->instance, $cutoffdate);
+        $params = [$USER->id, $cm->instance, $cutoffdate];
         $sql = "SELECT COUNT(p.id)
                   FROM {moodleoverflow_posts} p
                   JOIN {moodleoverflow_discussions} d ON p.discussion = d.id

--- a/classes/review.php
+++ b/classes/review.php
@@ -72,7 +72,7 @@ class review {
                 'FROM {moodleoverflow_posts} ' .
                 'WHERE discussion = :discussionid AND reviewed = 0 AND created < :cutofftime', [
                         'discussionid' => $discussionid,
-                        'cutofftime' => time() - get_config('moodleoverflow', 'reviewpossibleaftertime')
+                        'cutofftime' => time() - get_config('moodleoverflow', 'reviewpossibleaftertime'),
                 ]
         );
     }
@@ -89,7 +89,7 @@ class review {
 
         $params = [
                 'moodleoverflowid' => $moodleoverflowid,
-                'reviewtime' => time() - get_config('moodleoverflow', 'reviewpossibleaftertime')
+                'reviewtime' => time() - get_config('moodleoverflow', 'reviewpossibleaftertime'),
         ];
         $orderby = '';
         $addwhere = '';
@@ -117,7 +117,7 @@ class review {
         );
         if ($record) {
             return (new \moodle_url('/mod/moodleoverflow/discussion.php', [
-                'd' => $record->discussionid
+                'd' => $record->discussionid,
             ], 'p' . $record->postid))->out(false);
         } else {
             return null;
@@ -162,7 +162,7 @@ class review {
                 'JOIN {moodleoverflow_discussions} d ON d.id = p.discussion ' .
                 'WHERE d.moodleoverflow = :moodleoverflowid AND p.created < :cutofftime AND reviewed = 0', [
                         'moodleoverflowid' => $moodleoverflowid,
-                        'cutofftime' => time() - get_config('moodleoverflow', 'reviewpossibleaftertime')
+                        'cutofftime' => time() - get_config('moodleoverflow', 'reviewpossibleaftertime'),
                 ]
         );
     }

--- a/classes/subscriptions.php
+++ b/classes/subscriptions.php
@@ -51,7 +51,7 @@ class subscriptions {
      *
      * @var array[] An array of arrays.
      */
-    protected static $moodleoverflowcache = array();
+    protected static $moodleoverflowcache = [];
 
     /**
      * The list of moodleoverflows which have been wholly retrieved for the subscription cache.
@@ -61,7 +61,7 @@ class subscriptions {
      *
      * @var bool[]
      */
-    protected static $fetchedmoodleoverflows = array();
+    protected static $fetchedmoodleoverflows = [];
 
     /**
      * The subscription cache for moodleoverflow discussions.
@@ -73,7 +73,7 @@ class subscriptions {
      *
      * @var array[]
      */
-    protected static $discussioncache = array();
+    protected static $discussioncache = [];
 
     /**
      * The list of moodleoverflows which have been wholly retrieved for the discussion subscription cache.
@@ -83,7 +83,7 @@ class subscriptions {
      *
      * @var bool[]
      */
-    protected static $fetcheddiscussions = array();
+    protected static $fetcheddiscussions = [];
 
     /**
      * Returns whether a user is subscribed to this moodleoverflow or a specific discussion within the moodleoverflow.
@@ -194,14 +194,14 @@ class subscriptions {
 
                 // Create the cache for the user.
                 if (!isset(self::$moodleoverflowcache[$userid])) {
-                    self::$moodleoverflowcache[$userid] = array();
+                    self::$moodleoverflowcache[$userid] = [];
                 }
 
                 // Check if the user is subscribed to the moodleoverflow.
                 if (!isset(self::$moodleoverflowcache[$userid][$moodleoverflowid])) {
 
                     // Request to the database.
-                    $params = array('userid' => $userid, 'moodleoverflow' => $moodleoverflowid);
+                    $params = ['userid' => $userid, 'moodleoverflow' => $moodleoverflowid];
                     if ($DB->record_exists('moodleoverflow_subscriptions', $params)) {
                         self::$moodleoverflowcache[$userid][$moodleoverflowid] = true;
                     } else {
@@ -212,7 +212,7 @@ class subscriptions {
             } else { // The request is not connected to a specific user.
 
                 // Request all records.
-                $params = array('moodleoverflow' => $moodleoverflowid);
+                $params = ['moodleoverflow' => $moodleoverflowid];
                 $subscriptions = $DB->get_recordset('moodleoverflow_subscriptions', $params, '', 'id, userid');
 
                 // Loop through the records.
@@ -220,7 +220,7 @@ class subscriptions {
 
                     // Create a new record if necessary.
                     if (!isset(self::$moodleoverflowcache[$data->userid])) {
-                        self::$moodleoverflowcache[$data->userid] = array();
+                        self::$moodleoverflowcache[$data->userid] = [];
                     }
 
                     // Mark the subscription state.
@@ -250,7 +250,7 @@ class subscriptions {
 
         // Create an array, if there is no record.
         if (!isset(self::$discussioncache[$userid]) || !isset(self::$discussioncache[$userid][$moodleoverflowid])) {
-            return array();
+            return [];
         }
 
         // Return the cached subscription state.
@@ -277,14 +277,14 @@ class subscriptions {
 
                 // Create a new record if necessary.
                 if (!isset(self::$discussioncache[$userid])) {
-                    self::$discussioncache[$userid] = array();
+                    self::$discussioncache[$userid] = [];
                 }
 
                 // Check if the moodleoverflow instance is already cached.
                 if (!isset(self::$discussioncache[$userid][$moodleoverflowid])) {
 
                     // Get all records.
-                    $params = array('userid' => $userid, 'moodleoverflow' => $moodleoverflowid);
+                    $params = ['userid' => $userid, 'moodleoverflow' => $moodleoverflowid];
                     $subscriptions = $DB->get_recordset('moodleoverflow_discuss_subs', $params,
                         null, 'id, discussion, preference');
 
@@ -301,7 +301,7 @@ class subscriptions {
                 // No user ID is submitted.
 
                 // Get all records.
-                $params = array('moodleoverflow' => $moodleoverflowid);
+                $params = ['moodleoverflow' => $moodleoverflowid];
                 $subscriptions = $DB->get_recordset('moodleoverflow_discuss_subs', $params,
                     null, 'id, userid, discussion, preference');
 
@@ -329,12 +329,12 @@ class subscriptions {
 
         // Create a new array for the user if necessary.
         if (!isset(self::$discussioncache[$userid])) {
-            self::$discussioncache[$userid] = array();
+            self::$discussioncache[$userid] = [];
         }
 
         // Create a new array for the moodleoverflow if necessary.
         if (!isset(self::$discussioncache[$userid][$moodleoverflowid])) {
-            self::$discussioncache[$userid][$moodleoverflowid] = array();
+            self::$discussioncache[$userid][$moodleoverflowid] = [];
         }
 
         // Save the users preference for that discussion in this array.
@@ -390,7 +390,7 @@ class subscriptions {
         global $DB;
 
         // Change the value in the database.
-        return $DB->set_field('moodleoverflow', 'forcesubscribe', $status, array('id' => $moodleoverflowid));
+        return $DB->set_field('moodleoverflow', 'forcesubscribe', $status, ['id' => $moodleoverflowid]);
     }
 
     /**
@@ -415,11 +415,11 @@ class subscriptions {
         // Get courses that the current user is enrolled to.
         $courses = enrol_get_my_courses();
         if (empty($courses)) {
-            return array();
+            return [];
         }
 
         // Get the IDs of all that courses.
-        $courseids = array();
+        $courseids = [];
         foreach ($courses as $course) {
             $courseids[] = $course->id;
         }
@@ -436,14 +436,14 @@ class subscriptions {
                 JOIN {modules} mo ON mo.name = :modulename AND mo.id = cm.module
                 LEFT JOIN {moodleoverflow_subscriptions} ms ON (ms.moodleoverflow = m.id AND ms.userid = :userid)
                 WHERE m.forcesubscribe <> :forcesubscribe AND ms.id IS NOT NULL AND cm.course $coursesql";
-        $params = array('modulename' => 'moodleoverflow',
+        $params = ['modulename' => 'moodleoverflow',
                                  'userid' => $USER->id,
-                                 'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE);
+                                 'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE];
         $mergedparams = array_merge($courseparams, $params);
         $moodleoverflows = $DB->get_recordset_sql($sql, $mergedparams);
 
         // Loop through all of the results and add them to an array.
-        $unsubscribablemoodleoverflows = array();
+        $unsubscribablemoodleoverflows = [];
         foreach ($moodleoverflows as $moodleoverflow) {
             $unsubscribablemoodleoverflows[] = $moodleoverflow;
         }
@@ -494,7 +494,7 @@ class subscriptions {
 
         // Create an array for the user if necessary.
         if (!isset(self::$moodleoverflowcache[$userid])) {
-            self::$moodleoverflowcache[$userid] = array();
+            self::$moodleoverflowcache[$userid] = [];
         }
 
         // Fetch a record set for all moodleoverflowids and their subscription id.
@@ -502,11 +502,11 @@ class subscriptions {
                   FROM {moodleoverflow} m
              LEFT JOIN {moodleoverflow_subscriptions} s ON (s.moodleoverflow = m.id AND s.userid = :userid)
                  WHERE m.course = :course AND m.forcesubscribe <> :subscriptionforced";
-        $params = array(
+        $params = [
             'userid' => $userid,
             'course' => $courseid,
             'subscriptionforced' => MOODLEOVERFLOW_FORCESUBSCRIBE,
-        );
+        ];
         $subscriptions = $DB->get_recordset_sql($sql, $params);
 
         // Loop through all records.
@@ -616,10 +616,10 @@ class subscriptions {
     public static function reset_discussion_cache() {
 
         // Reset the discussion cache.
-        self::$discussioncache = array();
+        self::$discussioncache = [];
 
         // Reset the fetched discussions.
-        self::$fetcheddiscussions = array();
+        self::$fetcheddiscussions = [];
     }
 
     /**
@@ -631,10 +631,10 @@ class subscriptions {
     public static function reset_moodleoverflow_cache() {
 
         // Reset the cache.
-        self::$moodleoverflowcache = array();
+        self::$moodleoverflowcache = [];
 
         // Reset the fetched moodleoverflows.
-        self::$fetchedmoodleoverflows = array();
+        self::$fetchedmoodleoverflows = [];
     }
 
     /**
@@ -667,10 +667,10 @@ class subscriptions {
         if ($userrequest) {
 
             // Delete all those discussion subscriptions.
-            $params = array(
+            $params = [
                 'userid' => $userid,
                 'moodleoverflowid' => $moodleoverflow->id,
-                'preference' => self::MOODLEOVERFLOW_DISCUSSION_UNSUBSCRIBED);
+                'preference' => self::MOODLEOVERFLOW_DISCUSSION_UNSUBSCRIBED];
             $where = 'userid = :userid AND moodleoverflow = :moodleoverflowid AND preference <> :preference';
             $DB->delete_records_select('moodleoverflow_discuss_subs', $where, $params);
 
@@ -689,12 +689,12 @@ class subscriptions {
         self::$moodleoverflowcache[$userid][$moodleoverflow->id] = true;
 
         // Trigger an subscription created event.
-        $params = array(
+        $params = [
             'context' => $context,
             'objectid' => $result,
             'relateduserid' => $userid,
-            'other' => array('moodleoverflowid' => $moodleoverflow->id),
-        );
+            'other' => ['moodleoverflowid' => $moodleoverflow->id],
+        ];
         $event = event\subscription_created::create($params);
         $event->trigger();
 
@@ -716,26 +716,26 @@ class subscriptions {
         global $DB;
 
         // Check if there is a subscription record.
-        $params = array('userid' => $userid, 'moodleoverflow' => $moodleoverflow->id);
+        $params = ['userid' => $userid, 'moodleoverflow' => $moodleoverflow->id];
         if ($subscription = $DB->get_record('moodleoverflow_subscriptions', $params)) {
 
             // Delete this record.
-            $DB->delete_records('moodleoverflow_subscriptions', array('id' => $subscription->id));
+            $DB->delete_records('moodleoverflow_subscriptions', ['id' => $subscription->id]);
 
             // Was the unsubscription requested by the user?
             if ($userrequest) {
 
                 // Delete the discussion subscriptions as well.
-                $params = array(
+                $params = [
                     'userid' => $userid,
                     'moodleoverflow' => $moodleoverflow->id,
                     'preference' => self::MOODLEOVERFLOW_DISCUSSION_UNSUBSCRIBED,
-                );
+                ];
                 $DB->delete_records('moodleoverflow_discuss_subs', $params);
 
                 // Update the discussion cache.
                 if (isset(self::$discussioncache[$userid]) && isset(self::$discussioncache[$userid][$moodleoverflow->id])) {
-                    self::$discussioncache[$userid][$moodleoverflow->id] = array();
+                    self::$discussioncache[$userid][$moodleoverflow->id] = [];
                 }
             }
 
@@ -743,12 +743,12 @@ class subscriptions {
             self::$moodleoverflowcache[$userid][$moodleoverflow->id] = false;
 
             // Trigger an subscription deletion event.
-            $params = array(
+            $params = [
                 'context' => $context,
                 'objectid' => $subscription->id,
                 'relateduserid' => $userid,
-                'other' => array('moodleoverflowid' => $moodleoverflow->id),
-            );
+                'other' => ['moodleoverflowid' => $moodleoverflow->id],
+            ];
             $event = event\subscription_deleted::create($params);
             $event->add_record_snapshot('moodleoverflow_subscriptions', $subscription);
             $event->trigger();
@@ -771,7 +771,7 @@ class subscriptions {
         global $DB;
 
         // Check if the user is already subscribed to the discussion.
-        $params = array('userid' => $userid, 'discussion' => $discussion->id);
+        $params = ['userid' => $userid, 'discussion' => $discussion->id];
         $subscription = $DB->get_record('moodleoverflow_discuss_subs', $params);
 
         // Dont continue if the user is already subscribed.
@@ -780,14 +780,14 @@ class subscriptions {
         }
 
         // Check if the user is already subscribed to the moodleoverflow.
-        $params = array('userid' => $userid, 'moodleoverflow' => $discussion->moodleoverflow);
+        $params = ['userid' => $userid, 'moodleoverflow' => $discussion->moodleoverflow];
         if ($DB->record_exists('moodleoverflow_subscriptions', $params)) {
 
             // Check if the user is unsubscribed from the discussion.
             if ($subscription && $subscription->preference == self::MOODLEOVERFLOW_DISCUSSION_UNSUBSCRIBED) {
 
                 // Delete the discussion preference.
-                $DB->delete_records('moodleoverflow_discuss_subs', array('id' => $subscription->id));
+                $DB->delete_records('moodleoverflow_discuss_subs', ['id' => $subscription->id]);
                 unset(self::$discussioncache[$userid][$discussion->moodleoverflow][$discussion->id]);
 
             } else {
@@ -820,12 +820,12 @@ class subscriptions {
         }
 
         // Create a discussion subscription created event.
-        $params = array(
+        $params = [
             'context' => $context,
             'objectid' => $subscription->id,
             'relateduserid' => $userid,
-            'other' => array('moodleoverflowid' => $discussion->moodleoverflow, 'discussion' => $discussion->id),
-        );
+            'other' => ['moodleoverflowid' => $discussion->moodleoverflow, 'discussion' => $discussion->id],
+        ];
         $event = event\discussion_subscription_created::create($params);
         $event->trigger();
 
@@ -846,7 +846,7 @@ class subscriptions {
         global $DB;
 
         // Check the users subscription preference for this discussion.
-        $params = array('userid' => $userid, 'discussion' => $discussion->id);
+        $params = ['userid' => $userid, 'discussion' => $discussion->id];
         $subscription = $DB->get_record('moodleoverflow_discuss_subs', $params);
 
         // If the user not already subscribed to the discussion, do not continue.
@@ -855,14 +855,14 @@ class subscriptions {
         }
 
         // Check if the user is subscribed to the moodleoverflow.
-        $params = array('userid' => $userid, 'moodleoverflow' => $discussion->moodleoverflow);
+        $params = ['userid' => $userid, 'moodleoverflow' => $discussion->moodleoverflow];
         if (!$DB->record_exists('moodleoverflow_subscriptions', $params)) {
 
             // Check if the user isn't subscribed to the moodleoverflow.
             if ($subscription && $subscription->preference != self::MOODLEOVERFLOW_DISCUSSION_UNSUBSCRIBED) {
 
                 // Delete the discussion subscription.
-                $DB->delete_records('moodleoverflow_discuss_subs', array('id' => $subscription->id));
+                $DB->delete_records('moodleoverflow_discuss_subs', ['id' => $subscription->id]);
                 unset(self::$discussioncache[$userid][$discussion->moodleoverflow][$discussion->id]);
 
             } else {
@@ -901,12 +901,12 @@ class subscriptions {
         }
 
         // Trigger an discussion subscription deletetion event.
-        $params = array(
+        $params = [
             'context' => $context,
             'objectid' => $subscription->id,
             'relateduserid' => $userid,
-            'other' => array('moodleoverflowid' => $discussion->moodleoverflow, 'discussion' => $discussion->id),
-        );
+            'other' => ['moodleoverflowid' => $discussion->moodleoverflow, 'discussion' => $discussion->id],
+        ];
         $event = event\discussion_subscription_deleted::create($params);
         $event->trigger();
 
@@ -926,16 +926,16 @@ class subscriptions {
      *
      * @return string
      */
-    public static function moodleoverflow_get_subscribe_link($moodleoverflow, $context, $messages = array()) {
+    public static function moodleoverflow_get_subscribe_link($moodleoverflow, $context, $messages = []) {
         global $USER, $OUTPUT;
 
         // Define strings.
-        $defaultmessages = array(
+        $defaultmessages = [
             'subscribed' => get_string('unsubscribe', 'moodleoverflow'),
             'unsubscribed' => get_string('subscribe', 'moodleoverflow'),
             'forcesubscribed' => get_string('everyoneissubscribed', 'moodleoverflow'),
             'cantsubscribe' => get_string('disallowsubscribe', 'moodleoverflow'),
-        );
+        ];
 
         // Combine strings the submitted messages.
         $messages = $messages + $defaultmessages;
@@ -969,7 +969,7 @@ class subscriptions {
             }
 
             // Create an options array.
-            $options = array();
+            $options = [];
             $options['id'] = $moodleoverflow->id;
             $options['sesskey'] = sesskey();
             $options['returnurl'] = 0;
@@ -978,7 +978,7 @@ class subscriptions {
             // Return the link to subscribe the user.
             $url = new \moodle_url('/mod/moodleoverflow/subscribe.php', $options);
 
-            return $OUTPUT->single_button($url, $linktext, 'get', array('title' => $linktitle));
+            return $OUTPUT->single_button($url, $linktext, 'get', ['title' => $linktitle]);
         }
     }
 
@@ -1044,12 +1044,12 @@ class subscriptions {
         $status = self::is_subscribed($USER->id, $moodleoverflow, $context, $discussionid);
 
         // Create a link to subscribe or unsubscribe to the discussion.
-        $array = array(
+        $array = [
             'sesskey' => sesskey(),
             'id' => $moodleoverflow->id,
             'd' => $discussionid,
             'returnurl' => $returnurl,
-        );
+        ];
         $subscriptionlink = new \moodle_url('/mod/moodleoverflow/subscribe.php', $array);
 
         // Create an icon to unsubscribe.
@@ -1060,13 +1060,13 @@ class subscriptions {
             $output = $OUTPUT->pix_icon('i/subscribed', $string, 'mod_moodleoverflow');
 
             // Return the link.
-            $array = array(
+            $array = [
                 'title' => get_string('clicktounsubscribe', 'moodleoverflow'),
                 'class' => 'discussiontoggle text-muted',
                 'data-moodleoverflowid' => $moodleoverflow->id,
                 'data-discussionid' => $discussionid,
                 'data-includetext' => false,
-            );
+            ];
 
             return \html_writer::link($subscriptionlink, $output, $array);
         }
@@ -1076,13 +1076,13 @@ class subscriptions {
         $output = $OUTPUT->pix_icon('i/unsubscribed', $string, 'mod_moodleoverflow');
 
         // Return the link.
-        $array = array(
+        $array = [
             'title' => get_string('clicktosubscribe', 'moodleoverflow'),
             'class' => 'discussiontoggle text-muted',
             'data-moodleoverflowid' => $moodleoverflow->id,
             'data-discussionid' => $discussionid,
             'data-includetext' => false,
-        );
+        ];
 
         return \html_writer::link($subscriptionlink, $output, $array);
     }

--- a/classes/tables/userstats_table.php
+++ b/classes/tables/userstats_table.php
@@ -45,7 +45,7 @@ class userstats_table extends \flexible_table {
     private $moodleoverflowid;
 
     /** @var array table that will have objects with every user and his statistics. */
-    private $userstatsdata = array();
+    private $userstatsdata = [];
 
     /** @var \stdClass Help icon for amountofactivity-column.*/
     private $helpactivity;
@@ -267,7 +267,7 @@ class userstats_table extends \flexible_table {
         $this->helpactivity->icon = \html_writer::img($this->helpactivity->iconurl,
                                                       get_string('helpamountofactivity', 'moodleoverflow'));
         $this->helpactivity->class = 'helpactivityclass btn btn-link';
-        $this->helpactivity->iconattributes = array('role' => 'button',
+        $this->helpactivity->iconattributes = ['role' => 'button',
                                                     'data-container' => 'body',
                                                     'data-toggle' => 'popover',
                                                     'data-placement' => 'right',
@@ -277,7 +277,7 @@ class userstats_table extends \flexible_table {
                                                     'tabindex' => '0',
                                                     'data-content' => '<div class=&quot;no-overflow&quot;><p>' .
                                                                       get_string('helpamountofactivity', 'moodleoverflow') .
-                                                                      '</p> </div>');
+                                                                      '</p> </div>'];
 
         $this->helpactivity->object = \html_writer::span($this->helpactivity->icon,
                                                          $this->helpactivity->class,
@@ -381,10 +381,10 @@ class userstats_table extends \flexible_table {
         $student = new \stdClass();
         $student->id = $user->id;
         $student->name = $user->firstname . ' ' . $user->lastname;
-        $linktostudent = new \moodle_url('/user/view.php', array('id' => $student->id, 'course' => $this->courseid));
+        $linktostudent = new \moodle_url('/user/view.php', ['id' => $student->id, 'course' => $this->courseid]);
         $student->link = \html_writer::link($linktostudent->out(), $student->name);
-        $student->submittedposts = array(); // Posts written by the student. Key = postid, Value = postid.
-        $student->ratedposts = array();     // Posts that the student rated. Key = rateid, Value = rateid.
+        $student->submittedposts = []; // Posts written by the student. Key = postid, Value = postid.
+        $student->ratedposts = [];     // Posts that the student rated. Key = rateid, Value = rateid.
         $student->receivedupvotes = 0;
         $student->receiveddownvotes = 0;
         $student->forumactivity = 0;             // Number of written posts and submitted ratings in the current moodleoverflow.

--- a/classes/task/send_daily_mail.php
+++ b/classes/task/send_daily_mail.php
@@ -52,20 +52,20 @@ class send_daily_mail extends \core\task\scheduled_task {
         // Go through each user that has unread posts.
         foreach ($users as $user) {
             // Sorts the records with "Order by courseid".
-            $userdata = $DB->get_records('moodleoverflow_mail_info', array('userid' => $user->userid), 'courseid, forumid');
-            $mail = array();
+            $userdata = $DB->get_records('moodleoverflow_mail_info', ['userid' => $user->userid], 'courseid, forumid');
+            $mail = [];
             // Fill the $mail array.
             foreach ($userdata as $row) {
-                $currentcourse = $DB->get_record('course', array('id' => $row->courseid), 'fullname, id');
-                $currentforum = $DB->get_record('moodleoverflow', array('id' => $row->forumid), 'name, id');
+                $currentcourse = $DB->get_record('course', ['id' => $row->courseid], 'fullname, id');
+                $currentforum = $DB->get_record('moodleoverflow', ['id' => $row->forumid], 'name, id');
                 $coursemoduleid = get_coursemodule_from_instance('moodleoverflow', $row->forumid);
-                $discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $row->forumdiscussionid), 'name, id');
+                $discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $row->forumdiscussionid], 'name, id');
                 $unreadposts = $row->numberofposts;
 
                 // Build url to the course, forum, and discussion.
-                $linktocourse = new \moodle_url('/course/view.php', array('id' => $currentcourse->id));
-                $linktoforum = new \moodle_url('/mod/moodleoverflow/view.php', array('id' => $coursemoduleid->id));
-                $linktodiscussion = new \moodle_url('/mod/moodleoverflow/discussion.php', array('d' => $discussion->id));
+                $linktocourse = new \moodle_url('/course/view.php', ['id' => $currentcourse->id]);
+                $linktoforum = new \moodle_url('/mod/moodleoverflow/view.php', ['id' => $coursemoduleid->id]);
+                $linktodiscussion = new \moodle_url('/mod/moodleoverflow/discussion.php', ['d' => $discussion->id]);
 
                 // Now change the url to a clickable html link.
                 $linktocourse = \html_writer::link($linktocourse->out(), $currentcourse->fullname);
@@ -73,19 +73,19 @@ class send_daily_mail extends \core\task\scheduled_task {
                 $linktodiscussion = \html_writer::link($linktodiscussion->out(), $discussion->name);
 
                 // Build a single line string with the digest information and add it to the mailarray.
-                $string = get_string('digestunreadpost', 'mod_moodleoverflow', array('linktocourse' => $linktocourse,
+                $string = get_string('digestunreadpost', 'mod_moodleoverflow', ['linktocourse' => $linktocourse,
                                                                                      'linktoforum' => $linktoforum,
                                                                                      'linktodiscussion' => $linktodiscussion,
-                                                                                     'unreadposts' => $unreadposts));
+                                                                                     'unreadposts' => $unreadposts]);
                 array_push($mail, $string);
             }
             // Build the final message and send it to user. Then remove the sent records.
             $message = implode('<br>', $mail);
-            $userto = $DB->get_record('user', array('id' => $user->userid));
+            $userto = $DB->get_record('user', ['id' => $user->userid]);
             $from = \core_user::get_noreply_user();
             $subject = get_string('tasksenddailymail', 'mod_moodleoverflow');
             email_to_user($userto, $from, $subject, $message);
-            $DB->delete_records('moodleoverflow_mail_info', array('userid' => $user->userid));
+            $DB->delete_records('moodleoverflow_mail_info', ['userid' => $user->userid]);
         }
     }
 }

--- a/classes/task/send_mails.php
+++ b/classes/task/send_mails.php
@@ -79,7 +79,7 @@ class send_mails extends \core\task\scheduled_task {
             "ORDER BY d.course, d.moodleoverflow, d.id",
             [
                 'mailpending' => MOODLEOVERFLOW_MAILED_PENDING,
-                'timecutoff' => time() - get_config('moodleoverflow', 'reviewpossibleaftertime')
+                'timecutoff' => time() - get_config('moodleoverflow', 'reviewpossibleaftertime'),
             ]
         );
 
@@ -109,7 +109,7 @@ class send_mails extends \core\task\scheduled_task {
                 $userswithcapability = get_users_by_capability($modulecontext, 'mod/moodleoverflow:reviewpost');
                 $coursecontext = \context_course::instance($course->id);
                 $usersenrolled = get_enrolled_users($coursecontext);
-                $usersto = array();
+                $usersto = [];
                 foreach ($userswithcapability as $user) {
                     if (in_array($user, $usersenrolled)) {
                         array_push($usersto, $user);

--- a/db/access.php
+++ b/db/access.php
@@ -47,181 +47,181 @@
 defined('MOODLE_INTERNAL') || die();
 
 // Modify capabilities as needed and remove this comment.
-$capabilities = array(
-    'mod/moodleoverflow:addinstance' => array(
+$capabilities = [
+    'mod/moodleoverflow:addinstance' => [
         'riskbitmask' => RISK_XSS,
         'captype' => 'write',
         'contextlevel' => CONTEXT_COURSE,
-        'archetypes' => array(
+        'archetypes' => [
             'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        ),
-        'clonepermissionsfrom' => 'moodle/course:manageactivities'
-    ),
-    'mod/moodleoverflow:viewdiscussion' => array(
+            'manager' => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'moodle/course:manageactivities',
+    ],
+    'mod/moodleoverflow:viewdiscussion' => [
         'captype' => 'read',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'frontpage' => CAP_ALLOW,
             'guest' => CAP_ALLOW,
             'student' => CAP_ALLOW,
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        ),
-        'clonepermissionsfrom' => 'mod/forum:viewdiscussion'
-    ),
+            'manager' => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'mod/forum:viewdiscussion',
+    ],
 
-    'mod/moodleoverflow:replypost' => array(
+    'mod/moodleoverflow:replypost' => [
         'riskbitmask' => RISK_SPAM,
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'student' => CAP_ALLOW,
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        ),
-        'clonepermissionsfrom' => 'mod/forum:replypost'
-    ),
+            'manager' => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'mod/forum:replypost',
+    ],
 
-    'mod/moodleoverflow:startdiscussion' => array(
+    'mod/moodleoverflow:startdiscussion' => [
         'riskbitmask' => RISK_SPAM,
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'student' => CAP_ALLOW,
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        ),
-        'clonepermissionsfrom' => 'mod/forum:startdiscussion'
-    ),
+            'manager' => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'mod/forum:startdiscussion',
+    ],
 
-    'mod/moodleoverflow:editanypost' => array(
+    'mod/moodleoverflow:editanypost' => [
         'riskbitmask' => RISK_SPAM,
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        ),
-        'clonepermissionsfrom' => 'mod/forum:editanypost'
-    ),
+            'manager' => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'mod/forum:editanypost',
+    ],
 
-    'mod/moodleoverflow:deleteownpost' => array(
+    'mod/moodleoverflow:deleteownpost' => [
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'student' => CAP_ALLOW,
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        ),
-        'clonepermissionsfrom' => 'mod/forum:deleteownpost'
-    ),
+            'manager' => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'mod/forum:deleteownpost',
+    ],
 
-    'mod/moodleoverflow:deleteanypost' => array(
+    'mod/moodleoverflow:deleteanypost' => [
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        ),
-        'clonepermissionsfrom' => 'mod/forum:deleteanypost'
-    ),
-    'mod/moodleoverflow:ratepost' => array(
+            'manager' => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'mod/forum:deleteanypost',
+    ],
+    'mod/moodleoverflow:ratepost' => [
         'riskbitmask' => RISK_SPAM,
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'student' => CAP_ALLOW,
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        )
-    ),
+            'manager' => CAP_ALLOW,
+        ],
+    ],
 
-    'mod/moodleoverflow:marksolved' => array(
+    'mod/moodleoverflow:marksolved' => [
         'riskbitmask' => RISK_SPAM,
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'student' => CAP_PROHIBIT,
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        )
-    ),
+            'manager' => CAP_ALLOW,
+        ],
+    ],
 
-    'mod/moodleoverflow:managesubscriptions' => array(
+    'mod/moodleoverflow:managesubscriptions' => [
         'riskbitmask' => RISK_SPAM,
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        ),
-        'clonepermissionsfrom' => 'mod/forum:managesubscriptions'
-    ),
+            'manager' => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'mod/forum:managesubscriptions',
+    ],
 
-    'mod/moodleoverflow:allowforcesubscribe' => array(
+    'mod/moodleoverflow:allowforcesubscribe' => [
         'captype' => 'read',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'student' => CAP_ALLOW,
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'frontpage' => CAP_ALLOW
-        ),
-        'clonepermissionsfrom' => 'mod/forum:allowforcesubscribe'
-    ),
+            'frontpage' => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'mod/forum:allowforcesubscribe',
+    ],
 
-    'mod/moodleoverflow:createattachment' => array(
+    'mod/moodleoverflow:createattachment' => [
         'riskbitmask' => RISK_SPAM,
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'student' => CAP_ALLOW,
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        ),
-        'clonepermissionsfrom' => 'mod/forum:createattachment'
-    ),
+            'manager' => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'mod/forum:createattachment',
+    ],
 
-    'mod/moodleoverflow:reviewpost' => array(
+    'mod/moodleoverflow:reviewpost' => [
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-        ),
-    ),
+        ],
+    ],
 
-    'mod/moodleoverflow:movetopic' => array(
+    'mod/moodleoverflow:movetopic' => [
         'captype' => 'write',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        ),
-    ),
+            'manager' => CAP_ALLOW,
+        ],
+    ],
 
-    'mod/moodleoverflow:viewanyrating' => array(
+    'mod/moodleoverflow:viewanyrating' => [
         'riskbitmask' => RISK_PERSONAL,
         'captype' => 'read',
         'contextlevel' => CONTEXT_MODULE,
-        'archetypes' => array(
+        'archetypes' => [
             'teacher' => CAP_ALLOW,
             'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        ),
-        'clonepermissionsfrom' => 'mod/forum:viewanyrating'
-    ),
+            'manager' => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'mod/forum:viewanyrating',
+    ],
 
-);
+];

--- a/db/events.php
+++ b/db/events.php
@@ -24,24 +24,24 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$observers = array(
+$observers = [
 
     // Delete read records and subscriptions if the user is not anymore enrolled.
-    array(
+    [
         'eventname' => '\core\event\user_enrolment_deleted',
         'callback' => 'mod_moodleoverflow_observer::user_enrolment_deleted',
-    ),
+    ],
 
     // Subscribe the user to moodleoverflows which force him to when enroling a user.
-    array(
+    [
         'eventname' => '\core\event\role_assigned',
         'callback' => 'mod_moodleoverflow_observer::role_assigned',
-    ),
+    ],
 
     // Subscribe the user to moodleoverflows which force him to when creating an instance.
-    array(
+    [
         'eventname' => '\core\event\course_module_created',
         'callback' => 'mod_moodleoverflow_observer::course_module_created',
-    ),
+    ],
 
-);
+];

--- a/db/messages.php
+++ b/db/messages.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$messageproviders = array(
+$messageproviders = [
 
     // Ordinary single moodleoverflow posts.
-    'posts' => array(),
-);
+    'posts' => [],
+];

--- a/db/services.php
+++ b/db/services.php
@@ -24,30 +24,30 @@
  */
 defined('MOODLE_INTERNAL') || die;
 
-$functions = array(
-    'mod_moodleoverflow_record_vote' => array(
+$functions = [
+    'mod_moodleoverflow_record_vote' => [
         'classname' => 'mod_moodleoverflow_external',
         'methodname' => 'record_vote',
         'classpath' => 'mod/moodleoverflow/externallib.php',
         'description' => 'Records a vote and updates the reputation of a user',
         'type' => 'write',
         'ajax' => true,
-        'capabilities' => 'mod/moodleoverflow:ratepost'
-    ),
-    'mod_moodleoverflow_review_approve_post' => array(
+        'capabilities' => 'mod/moodleoverflow:ratepost',
+    ],
+    'mod_moodleoverflow_review_approve_post' => [
         'classname' => 'mod_moodleoverflow_external',
         'methodname' => 'review_approve_post',
         'classpath' => 'mod/moodleoverflow/externallib.php',
         'description' => 'Approves a post',
         'type' => 'write',
         'ajax' => true,
-    ),
-    'mod_moodleoverflow_review_reject_post' => array(
+    ],
+    'mod_moodleoverflow_review_reject_post' => [
         'classname' => 'mod_moodleoverflow_external',
         'methodname' => 'review_reject_post',
         'classpath' => 'mod/moodleoverflow/externallib.php',
         'description' => 'Rejects a post',
         'type' => 'write',
         'ajax' => true,
-    ),
-);
+    ],
+];

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -24,38 +24,38 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$tasks = array(
+$tasks = [
 
     // Deliver mail notification about new posts.
-    array(
+    [
         'classname' => 'mod_moodleoverflow\task\send_mails',
         'blocking' => 0,
         'minute' => '*',
         'hour' => '*',
         'day' => '*',
         'month' => '*',
-        'dayofweek' => '*'
-    ),
+        'dayofweek' => '*',
+    ],
 
     // Clean old read records.
-    array(
+    [
         'classname' => 'mod_moodleoverflow\task\clean_readrecords',
         'blocking' => 0,
         'minute' => '*',
         'hour' => '*',
         'day' => '*',
         'month' => '*',
-        'dayofweek' => '*'
-    ),
+        'dayofweek' => '*',
+    ],
 
     // Clean old read records.
-    array(
+    [
         'classname' => 'mod_moodleoverflow\task\send_daily_mail',
         'blocking' => 0,
         'minute' => '0',
         'hour' => '17',
         'day' => '*',
         'month' => '*',
-        'dayofweek' => '*'
-    )
-);
+        'dayofweek' => '*',
+    ],
+];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -94,8 +94,8 @@ function xmldb_moodleoverflow_upgrade($oldversion) {
         $table->add_field('grade', XMLDB_TYPE_FLOAT, '10', null, XMLDB_NOTNULL, null, '0');
 
         // Adding keys to table moodleoverflow_grades.
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
-        $table->add_key('moodleoverflowid', XMLDB_KEY_FOREIGN, array('moodleoverflowid'), 'moodleoverflow', array('id'));
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('moodleoverflowid', XMLDB_KEY_FOREIGN, ['moodleoverflowid'], 'moodleoverflow', ['id']);
 
         // Conditionally launch create table for moodleoverflow_grades.
         if (!$dbman->table_exists($table)) {
@@ -260,12 +260,12 @@ function xmldb_moodleoverflow_upgrade($oldversion) {
         $table->add_field('forumdiscussionid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
         $table->add_field('numberofposts', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
 
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
-        $table->add_key('userid', XMLDB_KEY_FOREIGN, array('userid'), 'user', array('id'));
-        $table->add_key('courseid', XMLDB_KEY_FOREIGN, array('courseid'), 'course', array('id'));
-        $table->add_key('forumid', XMLDB_KEY_FOREIGN, array('forumid'), 'moodleoverflow', array('id'));
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('userid', XMLDB_KEY_FOREIGN, ['userid'], 'user', ['id']);
+        $table->add_key('courseid', XMLDB_KEY_FOREIGN, ['courseid'], 'course', ['id']);
+        $table->add_key('forumid', XMLDB_KEY_FOREIGN, ['forumid'], 'moodleoverflow', ['id']);
         $table->add_key('forumdiscussionid', XMLDB_KEY_FOREIGN,
-                         array('forumdiscussionid'), 'moodleoverflow_discussions', array('id'));
+                         ['forumdiscussionid'], 'moodleoverflow_discussions', ['id']);
 
         // Conditionally launch create table for moodleoverflow_mail_info.
         if (!$dbman->table_exists($table)) {

--- a/discussion.php
+++ b/discussion.php
@@ -33,28 +33,28 @@ $ratingid = optional_param('r', 0, PARAM_INT);
 $ratedpost = optional_param('rp', 0, PARAM_INT);
 
 // Set the URL that should be used to return to this page.
-$PAGE->set_url('/mod/moodleoverflow/discussion.php', array('d' => $d));
+$PAGE->set_url('/mod/moodleoverflow/discussion.php', ['d' => $d]);
 
 // The page should not be large, only pages containing broad tables are usually.
 $PAGE->add_body_class('limitedwidth');
 
 // Check if the discussion is valid.
-if (!$discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $d))) {
+if (!$discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $d])) {
     throw new moodle_exception('invaliddiscussionid', 'moodleoverflow');
 }
 
 // Check if the related moodleoverflow instance is valid.
-if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $discussion->moodleoverflow))) {
+if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $discussion->moodleoverflow])) {
     throw new moodle_exception('invalidmoodleoverflowid', 'moodleoverflow');
 }
 
 // Check if the related moodleoverflow instance is valid.
-if (!$course = $DB->get_record('course', array('id' => $discussion->course))) {
+if (!$course = $DB->get_record('course', ['id' => $discussion->course])) {
     throw new moodle_exception('invalidcourseid');
 }
 
 // Save the allowmultiplemarks setting.
-$marksetting = $DB->get_record('moodleoverflow', array('id' => $moodleoverflow->id), 'allowmultiplemarks');
+$marksetting = $DB->get_record('moodleoverflow', ['id' => $moodleoverflow->id], 'allowmultiplemarks');
 $multiplemarks = false;
 if ($marksetting->allowmultiplemarks == 1) {
     $multiplemarks = true;
@@ -81,7 +81,7 @@ if (!$canviewdiscussion) {
 if ($ratingid) {
     require_sesskey();
 
-    if (in_array($ratingid, array(RATING_SOLVED, RATING_REMOVE_SOLVED, RATING_HELPFUL, RATING_REMOVE_HELPFUL))) {
+    if (in_array($ratingid, [RATING_SOLVED, RATING_REMOVE_SOLVED, RATING_HELPFUL, RATING_REMOVE_HELPFUL])) {
         // Rate the post.
         if (!\mod_moodleoverflow\ratings::moodleoverflow_add_rating($moodleoverflow, $ratedpost, $ratingid, $cm)) {
             throw new moodle_exception('ratingfailed', 'moodleoverflow');
@@ -94,10 +94,10 @@ if ($ratingid) {
 }
 
 // Trigger the discussion viewed event.
-$params = array(
+$params = [
     'context' => $modulecontext,
     'objectid' => $discussion->id,
-);
+];
 $event = \mod_moodleoverflow\event\discussion_viewed::create($params);
 $event->trigger();
 
@@ -130,7 +130,7 @@ if ($discussion->userid === '0') {
 }
 
 $node = $forumnode->add(format_string($discussion->name),
-    new moodle_url('/mod/moodleoverflow/discussion.php', array('d' => $discussion->id)));
+    new moodle_url('/mod/moodleoverflow/discussion.php', ['d' => $discussion->id]));
 $node->display = false;
 if ($node && ($post->id != $discussion->firstpost)) {
     $node->add(format_string($post->subject), $PAGE->url);

--- a/externallib.php
+++ b/externallib.php
@@ -45,10 +45,10 @@ class mod_moodleoverflow_external extends external_api {
      */
     public static function record_vote_parameters() {
         return new external_function_parameters(
-            array(
+            [
                 'postid' => new external_value(PARAM_INT, 'id of post'),
-                'ratingid' => new external_value(PARAM_INT, 'rating')
-            )
+                'ratingid' => new external_value(PARAM_INT, 'rating'),
+            ]
         );
     }
 
@@ -58,12 +58,12 @@ class mod_moodleoverflow_external extends external_api {
      */
     public static function record_vote_returns() {
         return new external_single_structure(
-            array(
+            [
                 'postrating' => new external_value(PARAM_INT, 'new post rating'),
                 'ownerreputation' => new external_value(PARAM_INT, 'new reputation of post owner'),
                 'raterreputation' => new external_value(PARAM_INT, 'new reputation of rater'),
                 'ownerid' => new external_value(PARAM_INT, 'user id of post owner'),
-            )
+            ]
         );
     }
 
@@ -78,27 +78,27 @@ class mod_moodleoverflow_external extends external_api {
         global $DB, $USER;
 
         // Parameter validation.
-        $params = self::validate_parameters(self::record_vote_parameters(), array(
+        $params = self::validate_parameters(self::record_vote_parameters(), [
             'postid' => $postid,
             'ratingid' => $ratingid,
-        ));
+        ]);
 
         $transaction = $DB->start_delegated_transaction();
 
-        $post = $DB->get_record('moodleoverflow_posts', array('id' => $params['postid']), '*', MUST_EXIST);
+        $post = $DB->get_record('moodleoverflow_posts', ['id' => $params['postid']], '*', MUST_EXIST);
 
         // Check if the discussion is valid.
-        if (!$discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $post->discussion))) {
+        if (!$discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $post->discussion])) {
             throw new moodle_exception('invaliddiscussionid', 'moodleoverflow');
         }
 
         // Check if the related moodleoverflow instance is valid.
-        if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $discussion->moodleoverflow))) {
+        if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $discussion->moodleoverflow])) {
             throw new moodle_exception('invalidmoodleoverflowid', 'moodleoverflow');
         }
 
         // Check if the related moodleoverflow instance is valid.
-        if (!$course = $DB->get_record('course', array('id' => $discussion->course))) {
+        if (!$course = $DB->get_record('course', ['id' => $discussion->course])) {
             throw new moodle_exception('invalidcourseid');
         }
 
@@ -147,7 +147,7 @@ class mod_moodleoverflow_external extends external_api {
      */
     public static function review_approve_post_parameters() {
         return new external_function_parameters([
-            'postid' => new external_value(PARAM_INT, 'id of post')
+            'postid' => new external_value(PARAM_INT, 'id of post'),
         ]);
     }
 
@@ -209,7 +209,7 @@ class mod_moodleoverflow_external extends external_api {
     public static function review_reject_post_parameters() {
         return new external_function_parameters([
             'postid' => new external_value(PARAM_INT, 'id of post'),
-            'reason' => new external_value(PARAM_RAW, 'reason of rejection')
+            'reason' => new external_value(PARAM_RAW, 'reason of rejection'),
         ]);
     }
 

--- a/index.php
+++ b/index.php
@@ -32,7 +32,7 @@ $id = required_param('id', PARAM_INT);
 $subscribe = optional_param('subscribe', null, PARAM_INT);
 
 // Set an url to go back to the page.
-$url = new moodle_url('/mod/moodleoverflow/index.php', array('id' => $id));
+$url = new moodle_url('/mod/moodleoverflow/index.php', ['id' => $id]);
 
 // Check whether the subscription parameter was set.
 if ($subscribe !== null) {
@@ -44,7 +44,7 @@ if ($subscribe !== null) {
 $PAGE->set_url($url);
 
 // Check if the id is related to a valid course.
-if (!$course = $DB->get_record('course', array('id' => $id))) {
+if (!$course = $DB->get_record('course', ['id' => $id])) {
     throw new moodle_exception('invalidcourseid');
 }
 
@@ -55,15 +55,15 @@ $coursecontext = context_course::instance($course->id);
 unset($SESSION->fromdiscussion);
 
 // Trigger the course module instace lise viewed evewnt.
-$params = array(
-    'context' => context_course::instance($course->id)
-);
+$params = [
+    'context' => context_course::instance($course->id),
+];
 $event = \mod_moodleoverflow\event\course_module_instance_list_viewed::create($params);
 $event->add_record_snapshot('course', $course);
 $event->trigger();
 
 // Cache some strings.
-$string = array();
+$string = [];
 $string['moodleoverflow'] = get_string('moodleoverflow', 'moodleoverflow');
 $string['moodleoverflows'] = get_string('moodleoverflows', 'moodleoverflow');
 $string['modulenameplural'] = get_string('modulenameplural', 'moodleoverflow');
@@ -86,8 +86,8 @@ $string['no'] = get_string('no');
 
 // Begin to print a table for the general area.
 $generaltable = new html_table();
-$generaltable->head = array($string['moodleoverflow'], $string['description'], $string['discussions']);
-$generaltable->align = array('left', 'left', 'center');
+$generaltable->head = [$string['moodleoverflow'], $string['description'], $string['discussions']];
+$generaltable->align = ['left', 'left', 'center'];
 
 // Check whether moodleoverflows can be tracked.
 $cantrack = \mod_moodleoverflow\readtracking::moodleoverflow_can_track_moodleoverflows();
@@ -111,7 +111,7 @@ $usesections = course_format_uses_sections($course->format);
 
 // Initiate tables and variables.
 $table = new html_table();
-$generalmoodleoverflows = array();
+$generalmoodleoverflows = [];
 $modinfo = get_fast_modinfo($course);
 $showsubscriptioncolumns = false;
 
@@ -119,7 +119,7 @@ $showsubscriptioncolumns = false;
 $sql = "SELECT m.*
           FROM {moodleoverflow} m
          WHERE m.course = ?";
-$moodleoverflows = $DB->get_records_sql($sql, array($course->id));
+$moodleoverflows = $DB->get_records_sql($sql, [$course->id]);
 
 // Loop through allmoodleoverflows.
 foreach ($modinfo->get_instances_of('moodleoverflow') as $moodleoverflowid => $cm) {
@@ -163,7 +163,7 @@ if (!is_null($subscribe)) {
     if (isguestuser() || !$showsubscriptioncolumns) {
 
         // Redirect the user back.
-        $url = new moodle_url('/mod/moodleoverflow/index.php', array('id' => $id));
+        $url = new moodle_url('/mod/moodleoverflow/index.php', ['id' => $id]);
         $notification = \core\output\notification::NOTIFY_ERROR;
         redirect($url, $string['subscribeenrolledonly'], null, $notification);
     }
@@ -210,11 +210,11 @@ if (!is_null($subscribe)) {
     }
 
     // Create an url to return the user back to.
-    $url = new moodle_url('/mod/moodleoverflow/index.php', array('id' => $id));
+    $url = new moodle_url('/mod/moodleoverflow/index.php', ['id' => $id]);
     $returnto = moodleoverflow_go_back_to($url);
 
     // Prepare the message to be displayed.
-    $shortname = format_string($course->shortname, true, array('context' => context_course::instance($course->id)));
+    $shortname = format_string($course->shortname, true, ['context' => context_course::instance($course->id)]);
     $notification = \core\output\notification::NOTIFY_SUCCESS;
 
     // Redirect the user depending on the subscription state.
@@ -291,15 +291,15 @@ if ($generalmoodleoverflows) {
                     // Tracking is optional.
 
                     // Define the url the button is linked to.
-                    $trackingurlparams = array('id' => $moodleoverflow->id, 'sesskey' => sesskey());
+                    $trackingurlparams = ['id' => $moodleoverflow->id, 'sesskey' => sesskey()];
                     $trackingurl = new moodle_url('/mod/moodleoverflow/tracking.php', $trackingurlparams);
 
                     // Check whether the moodleoverflow instance is tracked.
                     if (!isset($untracked[$moodleoverflow->id])) {
-                        $trackingparam = array('title' => $string['notrackmoodleoverflow']);
+                        $trackingparam = ['title' => $string['notrackmoodleoverflow']];
                         $trackedlink = $OUTPUT->single_button($trackingurl, $string['yes'], 'post', $trackingparam);
                     } else {
-                        $trackingparam = array('title' => $string['trackmoodleoverflow']);
+                        $trackingparam = ['title' => $string['trackmoodleoverflow']];
                         $trackedlink = $OUTPUT->single_button($trackingurl, $string['no'], 'post', $trackingparam);
                     }
                 }
@@ -323,7 +323,7 @@ if ($generalmoodleoverflows) {
         $discussionlink = "<a href=\"view.php?m=$moodleoverflow->id\" $style>" . $count . "</a>";
 
         // Create rows.
-        $row = array($moodleoverflowlink, $moodleoverflow->intro, $discussionlink);
+        $row = [$moodleoverflowlink, $moodleoverflow->intro, $discussionlink];
 
         // Add the tracking information to the rows.
         if ($cantrack) {
@@ -335,12 +335,12 @@ if ($generalmoodleoverflows) {
         if ($showsubscriptioncolumns) {
 
             // Set options to create the subscription link.
-            $suboptions = array(
+            $suboptions = [
                 'subscribed' => $string['yes'],
                 'unsubscribed' => $string['no'],
                 'forcesubscribed' => $string['yes'],
                 'cantsubscribe' => '-',
-            );
+            ];
 
             // Add the subscription link to the row.
             $row[] = \mod_moodleoverflow\subscriptions::moodleoverflow_get_subscribe_link($moodleoverflow,
@@ -369,7 +369,7 @@ if (!isguestuser() && isloggedin() && $showsubscriptioncolumns) {
     echo $OUTPUT->box_start('subscription');
 
     // Create the subscription link.
-    $urlparams = array('id' => $course->id, 'sesskey' => sesskey());
+    $urlparams = ['id' => $course->id, 'sesskey' => sesskey()];
     $subscriptionlink = new moodle_url('/mod/moodleoverflow/index.php', $urlparams);
 
     // Give the option to subscribe to all.

--- a/lib.php
+++ b/lib.php
@@ -182,7 +182,7 @@ function moodleoverflow_update_instance(stdClass $moodleoverflow, mod_moodleover
     $moodleoverflow->id = $moodleoverflow->instance;
 
     // Get the old record.
-    $oldmoodleoverflow = $DB->get_record('moodleoverflow', array('id' => $moodleoverflow->id));
+    $oldmoodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflow->id]);
 
     // Find the context of the module.
     $modulecontext = context_module::instance($moodleoverflow->coursemodule);
@@ -233,7 +233,7 @@ function moodleoverflow_refresh_events($courseid = 0) {
             return true;
         }
     } else {
-        if (!$moodleoverflows = $DB->get_records('moodleoverflow', array('course' => $courseid))) {
+        if (!$moodleoverflows = $DB->get_records('moodleoverflow', ['course' => $courseid])) {
             return true;
         }
     }
@@ -259,13 +259,13 @@ function moodleoverflow_delete_instance($id) {
     $result = true;
 
     // Get the needed objects.
-    if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $id))) {
+    if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $id])) {
         return false;
     }
     if (!$cm = get_coursemodule_from_instance('moodleoverflow', $moodleoverflow->id)) {
         return false;
     }
-    if (!$course = $DB->get_record('course', array('id' => $cm->course))) {
+    if (!$course = $DB->get_record('course', ['id' => $cm->course])) {
         return false;
     }
 
@@ -277,12 +277,12 @@ function moodleoverflow_delete_instance($id) {
     $fs->delete_area_files($context->id);
 
     // Delete the subscription elements.
-    $DB->delete_records('moodleoverflow_subscriptions', array('moodleoverflow' => $moodleoverflow->id));
-    $DB->delete_records('moodleoverflow_discuss_subs', array('moodleoverflow' => $moodleoverflow->id));
-    $DB->delete_records('moodleoverflow_grades', array('moodleoverflowid' => $moodleoverflow->id));
+    $DB->delete_records('moodleoverflow_subscriptions', ['moodleoverflow' => $moodleoverflow->id]);
+    $DB->delete_records('moodleoverflow_discuss_subs', ['moodleoverflow' => $moodleoverflow->id]);
+    $DB->delete_records('moodleoverflow_grades', ['moodleoverflowid' => $moodleoverflow->id]);
 
     // Delete the discussion recursivly.
-    if ($discussions = $DB->get_records('moodleoverflow_discussions', array('moodleoverflow' => $moodleoverflow->id))) {
+    if ($discussions = $DB->get_records('moodleoverflow_discussions', ['moodleoverflow' => $moodleoverflow->id])) {
         require_once('locallib.php');
         foreach ($discussions as $discussion) {
             if (!moodleoverflow_delete_discussion($discussion, $course, $cm, $moodleoverflow)) {
@@ -295,7 +295,7 @@ function moodleoverflow_delete_instance($id) {
     \mod_moodleoverflow\readtracking::moodleoverflow_delete_read_records(-1, -1, -1, $moodleoverflow->id);
 
     // Delete the moodleoverflow instance.
-    if (!$DB->delete_records('moodleoverflow', array('id' => $moodleoverflow->id))) {
+    if (!$DB->delete_records('moodleoverflow', ['id' => $moodleoverflow->id])) {
         $result = false;
     }
 
@@ -349,7 +349,7 @@ function moodleoverflow_print_recent_activity($course, $viewfullnames, $timestar
  * @return array
  */
 function moodleoverflow_get_extra_capabilities() {
-    return array();
+    return [];
 }
 
 /* File API */
@@ -367,10 +367,10 @@ function moodleoverflow_get_extra_capabilities() {
  * @return array of [(string)filearea] => (string)description
  */
 function moodleoverflow_get_file_areas($course, $cm, $context) {
-    return array(
+    return [
         'attachment' => get_string('areaattachment', 'mod_moodleoverflow'),
         'post' => get_string('areapost', 'mod_moodleoverflow'),
-    );
+    ];
 }
 
 /**
@@ -409,7 +409,7 @@ function moodleoverflow_get_file_info($browser, $areas, $course, $cm, $context, 
  * @param bool     $forcedownload whether or not force download
  * @param array    $options       additional options affecting the file serving
  */
-function moodleoverflow_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = array()) {
+function moodleoverflow_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, array $options = []) {
     global $DB, $CFG;
     if ($context->contextlevel != CONTEXT_MODULE) {
         return false;
@@ -426,13 +426,13 @@ function moodleoverflow_pluginfile($course, $cm, $context, $filearea, $args, $fo
     $itemid = array_pop($args);
 
     // Check if post, discussion or moodleoverflow still exists.
-    if (!$post = $DB->get_record('moodleoverflow_posts', array('id' => $itemid))) {
+    if (!$post = $DB->get_record('moodleoverflow_posts', ['id' => $itemid])) {
         return false;
     }
-    if (!$discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $post->discussion))) {
+    if (!$discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $post->discussion])) {
         return false;
     }
-    if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $cm->instance))) {
+    if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $cm->instance])) {
         return false;
     }
 
@@ -482,7 +482,7 @@ function moodleoverflow_extend_settings_navigation(settings_navigation $settings
     global $CFG, $DB, $PAGE, $USER;
 
     // Retrieve the current moodle record.
-    $moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $PAGE->cm->instance));
+    $moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $PAGE->cm->instance]);
 
     // Check if the user can subscribe to the instance.
     $enrolled = is_enrolled($PAGE->cm->context, $USER, '', false);
@@ -502,7 +502,7 @@ function moodleoverflow_extend_settings_navigation(settings_navigation $settings
 
         // Generate the link.
         $url = '/mod/moodleoverflow/index.php';
-        $params = array('id' => $moodleoverflow->course);
+        $params = ['id' => $moodleoverflow->course];
         $link = new moodle_url($url, $params);
 
         // Add the link to the menu.
@@ -521,7 +521,7 @@ function moodleoverflow_extend_settings_navigation(settings_navigation $settings
         }
 
         // Add the link to the menu.
-        $url = new moodle_url('/mod/moodleoverflow/subscribe.php', array('id' => $moodleoverflow->id, 'sesskey' => sesskey()));
+        $url = new moodle_url('/mod/moodleoverflow/subscribe.php', ['id' => $moodleoverflow->id, 'sesskey' => sesskey()]);
         $moodleoverflownode->add($linktext, $url, navigation_node::TYPE_SETTING);
     }
 
@@ -546,7 +546,7 @@ function moodleoverflow_extend_settings_navigation(settings_navigation $settings
 
             // Generate the link.
             $url = '/mod/moodleoverflow/tracking.php';
-            $params = array('id' => $moodleoverflow->id, 'sesskey' => sesskey());
+            $params = ['id' => $moodleoverflow->id, 'sesskey' => sesskey()];
             $link = new moodle_url($url, $params);
 
             // Add the link to the menu.
@@ -605,19 +605,19 @@ function moodleoverflow_send_mails() {
     $textout = $PAGE->get_renderer('mod_moodleoverflow', 'email', 'textemail');
 
     // Initiate the arrays that are saving the users that are subscribed to posts that needs sending.
-    $users = array();
+    $users = [];
     $userscount = 0; // Count($users) is slow. This avoids using this.
 
     // Status arrays.
-    $mailcount = array();
-    $errorcount = array();
+    $mailcount = [];
+    $errorcount = [];
 
     // Cache arrays.
-    $discussions = array();
-    $moodleoverflows = array();
-    $courses = array();
-    $coursemodules = array();
-    $subscribedusers = array();
+    $discussions = [];
+    $moodleoverflows = [];
+    $courses = [];
+    $coursemodules = [];
+    $subscribedusers = [];
 
     // Posts older than x days will not be mailed.
     // This will avoid problems with the cron not beeing ran for a long time.
@@ -644,7 +644,7 @@ function moodleoverflow_send_mails() {
             if (!isset($discussions[$discussionid])) {
 
                 // Retrieve the discussion from the database.
-                $discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $post->discussion));
+                $discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $post->discussion]);
 
                 // If there is a record, update the cache. Else ignore the post.
                 if ($discussion) {
@@ -663,7 +663,7 @@ function moodleoverflow_send_mails() {
             if (!isset($moodleoverflows[$moodleoverflowid])) {
 
                 // Retrieve the record from the database and update the cache.
-                $moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $moodleoverflowid));
+                $moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflowid]);
                 if ($moodleoverflow) {
                     $moodleoverflows[$moodleoverflowid] = $moodleoverflow;
                 } else {
@@ -678,7 +678,7 @@ function moodleoverflow_send_mails() {
             if (!isset($courses[$courseid])) {
 
                 // Retrieve the record from the database and update the cache.
-                $course = $DB->get_record('course', array('id' => $courseid));
+                $course = $DB->get_record('course', ['id' => $courseid]);
                 if ($course) {
                     $courses[$courseid] = $course;
                 } else {
@@ -746,9 +746,9 @@ function moodleoverflow_send_mails() {
             mtrace('Processing user ' . $userto->id);
             // Initiate the user caches to save memory.
             $userto = clone($userto);
-            $userto->ciewfullnames = array();
-            $userto->canpost = array();
-            $userto->markposts = array();
+            $userto->ciewfullnames = [];
+            $userto->canpost = [];
+            $userto->markposts = [];
 
             // Cache the capabilities of the user.
             // Check for moodle version. Version 401 supported until 8 December 2025.
@@ -761,7 +761,7 @@ function moodleoverflow_send_mails() {
             // Reset the caches.
             foreach ($coursemodules as $moodleoverflowid => $unused) {
                 $coursemodules[$moodleoverflowid]->cache = new stdClass();
-                $coursemodules[$moodleoverflowid]->cache->caps = array();
+                $coursemodules[$moodleoverflowid]->cache->caps = [];
                 unset($coursemodules[$moodleoverflowid]->uservisible);
             }
 
@@ -785,10 +785,10 @@ function moodleoverflow_send_mails() {
                     $dataobject->forumid = $moodleoverflow->id;
                     $dataobject->forumdiscussionid = $discussion->id;
                     $record = $DB->get_record('moodleoverflow_mail_info',
-                                                array('userid' => $dataobject->userid,
+                                                ['userid' => $dataobject->userid,
                                                       'courseid' => $dataobject->courseid,
                                                       'forumid' => $dataobject->forumid,
-                                                      'forumdiscussionid' => $dataobject->forumdiscussionid),
+                                                      'forumdiscussionid' => $dataobject->forumdiscussionid],
                                                       'numberofposts, id');
                     if (is_object($record)) {
                         $dataset = $record;
@@ -832,7 +832,7 @@ function moodleoverflow_send_mails() {
                         // We dont know the the user yet.
 
                         // Retrieve the user from the database.
-                        $userfrom = $DB->get_record('user', array('id' => $post->userid));
+                        $userfrom = $DB->get_record('user', ['id' => $post->userid]);
                         if ($userfrom) {
                             moodleoverflow_minimise_user_record($userfrom);
                         } else {
@@ -884,11 +884,11 @@ function moodleoverflow_send_mails() {
                 // Preapare to actually send the post now. Build up the content.
                 $cleanname = str_replace('"', "'", strip_tags(format_string($moodleoverflow->name)));
                 $coursecontext = context_course::instance($course->id);
-                $shortname = format_string($course->shortname, true, array('context' => $coursecontext));
+                $shortname = format_string($course->shortname, true, ['context' => $coursecontext]);
 
                 // Define a header to make mails easier to track.
                 $emailmessageid = generate_email_messageid('moodlemoodleoverflow' . $moodleoverflow->id);
-                $userfrom->customheaders = array(
+                $userfrom->customheaders = [
                     'List-Id: "' . $cleanname . '" ' . $emailmessageid,
                     'List-Help: ' . $CFG->wwwroot . '/mod/moodleoverflow/view.php?m=' . $moodleoverflow->id,
                     'Message-ID: ' . generate_email_messageid(hash('sha256', $post->id . 'to' . $userto->id)),
@@ -899,7 +899,7 @@ function moodleoverflow_send_mails() {
                     'Precedence: Bulk',
                     'X-Auto-Response-Suppress: All',
                     'Auto-Submitted: auto-generated',
-                );
+                ];
 
                 // Cache the users capabilities.
                 if (!isset($userto->canpost[$discussion->id])) {
@@ -986,7 +986,7 @@ function moodleoverflow_send_mails() {
 
                 // Generate the url to view the post.
                 $url = '/mod/moodleoverflow/discussion.php';
-                $params = array('d' => $discussion->id);
+                $params = ['d' => $discussion->id];
                 $contexturl = new moodle_url($url, $params, 'p' . $post->id);
                 $eventdata->contexturl = $contexturl->out();
                 $eventdata->contexturlname = $discussion->name;
@@ -1023,7 +1023,7 @@ function moodleoverflow_send_mails() {
 
             // Mark the posts with errors in the database.
             if ($errorcount[$post->id]) {
-                $DB->set_field('moodleoverflow_posts', 'mailed', MOODLEOVERFLOW_MAILED_ERROR, array('id' => $post->id));
+                $DB->set_field('moodleoverflow_posts', 'mailed', MOODLEOVERFLOW_MAILED_ERROR, ['id' => $post->id]);
             }
         }
     }
@@ -1044,7 +1044,7 @@ function moodleoverflow_get_unmailed_posts($starttime, $endtime) {
     global $DB;
 
     // Set params for the sql query.
-    $params = array();
+    $params = [];
     $params['ptimestart'] = $starttime;
     $params['ptimeend'] = $endtime;
 
@@ -1076,7 +1076,7 @@ function moodleoverflow_mark_old_posts_as_mailed($endtime) {
     $now = time();
 
     // Define variables for the sql query.
-    $params = array();
+    $params = [];
     $params['mailedsuccess'] = MOODLEOVERFLOW_MAILED_SUCCESS;
     $params['mailedreviewsent'] = MOODLEOVERFLOW_MAILED_REVIEW_SUCCESS;
     $params['now'] = $now;
@@ -1176,7 +1176,7 @@ function moodleoverflow_can_create_attachment($moodleoverflow, $context) {
 function moodleoverflow_get_user_grades($moodleoverflow, $userid=0) {
     global $CFG, $DB;
 
-    $params = array("moodleoverflowid" => $moodleoverflow->id);
+    $params = ["moodleoverflowid" => $moodleoverflow->id];
 
     $sql = "SELECT u.id AS userid, g.grade AS rawgrade
               FROM {user} u, {moodleoverflow_grades} g
@@ -1236,7 +1236,7 @@ function moodleoverflow_grade_item_update($moodleoverflow, $grades=null) {
         require_once($CFG->libdir.'/gradelib.php');
     }
 
-    $params = array('itemname' => $moodleoverflow->name, 'idnumber' => $moodleoverflow->id);
+    $params = ['itemname' => $moodleoverflow->name, 'idnumber' => $moodleoverflow->id];
 
     if ($moodleoverflow->grademaxgrade <= 0) {
         $params['gradetype'] = GRADE_TYPE_NONE;
@@ -1278,6 +1278,6 @@ function moodleoverflow_get_fontawesome_icon_map() {
         'mod_moodleoverflow:i/subscribed' => 'fa-bell moodleoverflow-icon-1_5x',
         'mod_moodleoverflow:i/unsubscribed' => 'fa-bell-slash-o moodleoverflow-icon-1_5x',
         'mod_moodleoverflow:i/vote-up' => 'fa-chevron-up moodleoverflow-icon-2x moodleoverflow-icon-no-margin',
-        'mod_moodleoverflow:i/vote-down' => 'fa-chevron-down moodleoverflow-icon-2x moodleoverflow-icon-no-margin'
+        'mod_moodleoverflow:i/vote-down' => 'fa-chevron-down moodleoverflow-icon-2x moodleoverflow-icon-no-margin',
     ];
 }

--- a/locallib.php
+++ b/locallib.php
@@ -928,12 +928,8 @@ function moodleoverflow_print_discussion($course, $cm, $moodleoverflow, $discuss
 
     // Retrieve all posts of the discussion.
     $posts = moodleoverflow_get_all_discussion_posts($discussion->id, $istracked, $modulecontext);
-    /*$newpost = [];
-    foreach($posts as $posti) {
-        $newpost[] = $posti->message;
-    }
-    var_dump($newpost);
-    */$usermapping = anonymous::get_userid_mapping($moodleoverflow, $discussion->id);
+
+    $usermapping = anonymous::get_userid_mapping($moodleoverflow, $discussion->id);
 
     // Start with the parent post.
     $post = $posts[$post->id];

--- a/locallib.php
+++ b/locallib.php
@@ -52,7 +52,7 @@ function moodleoverflow_get_discussions($cm, $page = -1, $perpage = 0) {
     // User must have the permission to view the discussions.
     $modcontext = context_module::instance($cm->id);
     if (!capabilities::has(capabilities::VIEW_DISCUSSION, $modcontext)) {
-        return array();
+        return [];
     }
 
     // Filter some defaults.
@@ -181,7 +181,7 @@ function moodleoverflow_print_latest_discussions($moodleoverflow, $cm, $page = -
         $unreads = moodleoverflow_get_discussions_unread($cm);
         $markallread = $CFG->wwwroot . '/mod/moodleoverflow/markposts.php?m=' . $moodleoverflow->id;
     } else {
-        $unreads = array();
+        $unreads = [];
         $markallread = null;
     }
 
@@ -223,9 +223,9 @@ function moodleoverflow_print_latest_discussions($moodleoverflow, $cm, $page = -
 
     // Iterate through every visible discussion.
     $i = 0;
-    $preparedarray = array();
+    $preparedarray = [];
     foreach ($discussions as $discussion) {
-        $preparedarray[$i] = array();
+        $preparedarray[$i] = [];
 
         // Handle anonymized discussions.
         if ($discussion->userid == 0) {
@@ -324,8 +324,8 @@ function moodleoverflow_print_latest_discussions($moodleoverflow, $cm, $page = -
             }
         } else {
             // Get his picture, his name and the link to his profile.
-            $preparedarray[$i]['picture'] = $OUTPUT->user_picture($startuser, array('courseid' => $moodleoverflow->course,
-                                                                                    'link' => false));
+            $preparedarray[$i]['picture'] = $OUTPUT->user_picture($startuser, ['courseid' => $moodleoverflow->course,
+                                                                                    'link' => false]);
             $preparedarray[$i]['username'] = fullname($startuser, has_capability('moodle/site:viewfullnames', $context));
             $preparedarray[$i]['userlink'] = $CFG->wwwroot . '/user/view.php?id=' .
                 $discussion->userid . '&course=' . $moodleoverflow->course;
@@ -384,7 +384,7 @@ function moodleoverflow_print_latest_discussions($moodleoverflow, $cm, $page = -
             $reviewinfo = review::get_short_review_info_for_discussion($discussion->discussion);
             $preparedarray[$i]['needreview'] = $reviewinfo->count;
             $preparedarray[$i]['reviewlink'] = (new moodle_url('/mod/moodleoverflow/discussion.php', [
-                'd' => $discussion->discussion
+                'd' => $discussion->discussion,
             ], 'p' . $reviewinfo->first))->out(false);
         }
 
@@ -447,10 +447,10 @@ function moodleoverflow_print_latest_discussions($moodleoverflow, $cm, $page = -
  */
 function moodleoverflow_print_forum_list($course, $cm, $movetopopup) {
     global $CFG, $DB, $PAGE;
-    $forumarray = array(array());
-    $currentforum = $DB->get_record('moodleoverflow_discussions', array('id' => $movetopopup), 'moodleoverflow');
-    $currentdiscussion = $DB->get_record('moodleoverflow_discussions', array('id' => $movetopopup), 'name');
-    $forums = $DB->get_records('moodleoverflow', array('course' => $course->id));
+    $forumarray = [[]];
+    $currentforum = $DB->get_record('moodleoverflow_discussions', ['id' => $movetopopup], 'moodleoverflow');
+    $currentdiscussion = $DB->get_record('moodleoverflow_discussions', ['id' => $movetopopup], 'name');
+    $forums = $DB->get_records('moodleoverflow', ['course' => $course->id]);
     $amountforums = count($forums);
 
     if ($amountforums > 1) {
@@ -599,7 +599,7 @@ function moodleoverflow_get_discussions_unread($cm) {
     $params = [
             'userid' => $USER->id,
             'instance' => $cm->instance,
-            'cutoffdate' => $cutoffdate
+            'cutoffdate' => $cutoffdate,
     ];
 
     if (!has_capability('mod/moodleoverflow:reviewpost', $modcontext)) {
@@ -627,7 +627,7 @@ function moodleoverflow_get_discussions_unread($cm) {
     } else {
 
         // If there are no unread messages, return an empty array.
-        return array();
+        return [];
     }
 }
 
@@ -652,7 +652,7 @@ function moodleoverflow_get_post_full($postid) {
                    JOIN {moodleoverflow_discussions} d ON p.discussion = d.id
               LEFT JOIN {user} u ON p.userid = u.id
                   WHERE p.id = :postid";
-    $params = array();
+    $params = [];
     $params['postid'] = $postid;
 
     $post = $DB->get_record_sql($sql, $params);
@@ -682,7 +682,7 @@ function moodleoverflow_user_can_see_post($moodleoverflow, $discussion, $post, $
     // Fetch the moodleoverflow instance object.
     if (is_numeric($moodleoverflow)) {
         debugging('missing full moodleoverflow', DEBUG_DEVELOPER);
-        if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $moodleoverflow))) {
+        if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflow])) {
             return false;
         }
     }
@@ -690,7 +690,7 @@ function moodleoverflow_user_can_see_post($moodleoverflow, $discussion, $post, $
     // Fetch the discussion object.
     if (is_numeric($discussion)) {
         debugging('missing full discussion', DEBUG_DEVELOPER);
-        if (!$discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $discussion))) {
+        if (!$discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $discussion])) {
             return false;
         }
     }
@@ -698,7 +698,7 @@ function moodleoverflow_user_can_see_post($moodleoverflow, $discussion, $post, $
     // Fetch the post object.
     if (is_numeric($post)) {
         debugging('missing full post', DEBUG_DEVELOPER);
-        if (!$post = $DB->get_record('moodleoverflow_posts', array('id' => $post))) {
+        if (!$post = $DB->get_record('moodleoverflow_posts', ['id' => $post])) {
             return false;
         }
     }
@@ -746,7 +746,7 @@ function moodleoverflow_user_can_see_discussion($moodleoverflow, $discussion, $c
     // Retrieve the moodleoverflow object.
     if (is_numeric($moodleoverflow)) {
         debugging('missing full moodleoverflow', DEBUG_DEVELOPER);
-        if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $moodleoverflow))) {
+        if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflow])) {
             return false;
         }
     }
@@ -754,7 +754,7 @@ function moodleoverflow_user_can_see_discussion($moodleoverflow, $discussion, $c
     // Retrieve the discussion object.
     if (is_numeric($discussion)) {
         debugging('missing full discussion', DEBUG_DEVELOPER);
-        if (!$discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $discussion))) {
+        if (!$discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $discussion])) {
             return false;
         }
     }
@@ -791,7 +791,7 @@ function moodleoverflow_add_discussion($discussion, $modulecontext, $userid = nu
     // as a real post. The discussion links to it.
 
     // Retrieve the module instance.
-    if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $discussion->moodleoverflow))) {
+    if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $discussion->moodleoverflow])) {
         return false;
     }
 
@@ -836,7 +836,7 @@ function moodleoverflow_add_discussion($discussion, $modulecontext, $userid = nu
     $post->discussion = $DB->insert_record('moodleoverflow_discussions', $discussionobject);
 
     // Link the post to the discussion.
-    $DB->set_field('moodleoverflow_posts', 'discussion', $post->discussion, array('id' => $post->id));
+    $DB->set_field('moodleoverflow_posts', 'discussion', $post->discussion, ['id' => $post->id]);
 
     moodleoverflow_add_attachment($post, $moodleoverflow, $cm);
 
@@ -848,10 +848,10 @@ function moodleoverflow_add_discussion($discussion, $modulecontext, $userid = nu
     }
 
     // Trigger event.
-    $params = array(
+    $params = [
         'context' => $modulecontext,
         'objectid' => $post->discussion,
-    );
+    ];
 
     $event = \mod_moodleoverflow\event\discussion_viewed::create($params);
     $event->trigger();
@@ -1004,10 +1004,10 @@ function moodleoverflow_get_all_discussion_posts($discussionid, $tracking, $modc
     global $DB, $USER, $CFG;
 
     // Initiate tracking settings.
-    $params = array();
+    $params = [];
     $trackingselector = "";
     $trackingjoin = "";
-    $params = array();
+    $params = [];
 
     // If tracking is enabled, another join is needed.
     if ($tracking) {
@@ -1043,7 +1043,7 @@ function moodleoverflow_get_all_discussion_posts($discussionid, $tracking, $modc
 
     // Return an empty array, if there are no posts.
     if (!$posts = $DB->get_records_sql($sql, $params)) {
-        return array();
+        return [];
     }
 
     // Load all ratings.
@@ -1086,7 +1086,7 @@ function moodleoverflow_get_all_discussion_posts($discussionid, $tracking, $modc
 
         // Create the children array.
         if (!isset($posts[$post->parent]->children)) {
-            $posts[$post->parent]->children = array();
+            $posts[$post->parent]->children = [];
         }
 
         // Increase the level of the current post.
@@ -1190,7 +1190,7 @@ function moodleoverflow_print_post($post, $discussion, $moodleoverflow, $cm, $co
     }
 
     // Get the current link without unnecessary parameters.
-    $discussionlink = new moodle_url('/mod/moodleoverflow/discussion.php', array('d' => $post->discussion));
+    $discussionlink = new moodle_url('/mod/moodleoverflow/discussion.php', ['d' => $post->discussion]);
 
     // Build the object that represents the posting user.
     $postinguser = new stdClass();
@@ -1206,19 +1206,19 @@ function moodleoverflow_print_post($post, $discussion, $moodleoverflow, $cm, $co
         $postinguser->id = null;
         if ($post->userid == $USER->id) {
             $postinguser->fullname = get_string('anonym_you', 'mod_moodleoverflow');
-            $postinguser->profilelink = new moodle_url('/user/view.php', array('id' => $post->userid, 'course' => $course->id));
+            $postinguser->profilelink = new moodle_url('/user/view.php', ['id' => $post->userid, 'course' => $course->id]);
         } else {
             $postinguser->fullname = $usermapping[(int) $post->userid];
             $postinguser->profilelink = null;
         }
     } else {
         $postinguser->fullname = fullname($postinguser, capabilities::has('moodle/site:viewfullnames', $modulecontext));
-        $postinguser->profilelink = new moodle_url('/user/view.php', array('id' => $post->userid, 'course' => $course->id));
+        $postinguser->profilelink = new moodle_url('/user/view.php', ['id' => $post->userid, 'course' => $course->id]);
         $postinguser->id = $post->userid;
     }
 
     // Prepare an array of commands.
-    $commands = array();
+    $commands = [];
 
     // Create a permalink.
     $permalink = new moodle_url($discussionlink);
@@ -1240,15 +1240,15 @@ function moodleoverflow_print_post($post, $discussion, $moodleoverflow, $cm, $co
         $link = '/mod/moodleoverflow/discussion.php';
         if ($post->markedhelpful) {
             $commands[] = html_writer::tag('a', $str->marknothelpful,
-                    array('class' => 'markhelpful onlyifreviewed', 'role' => 'button', 'data-moodleoverflow-action' => 'helpful'));
+                    ['class' => 'markhelpful onlyifreviewed', 'role' => 'button', 'data-moodleoverflow-action' => 'helpful']);
         } else {
             // If there are already marked posts, change the string of the button.
             if ($helpfulposts) {
                 $commands[] = html_writer::tag('a', $str->alsomarkhelpful,
-                    array('class' => 'markhelpful onlyifreviewed', 'role' => 'button', 'data-moodleoverflow-action' => 'helpful'));
+                    ['class' => 'markhelpful onlyifreviewed', 'role' => 'button', 'data-moodleoverflow-action' => 'helpful']);
             } else {
                 $commands[] = html_writer::tag('a', $str->markhelpful,
-                    array('class' => 'markhelpful onlyifreviewed', 'role' => 'button', 'data-moodleoverflow-action' => 'helpful'));
+                    ['class' => 'markhelpful onlyifreviewed', 'role' => 'button', 'data-moodleoverflow-action' => 'helpful']);
             }
         }
     }
@@ -1262,15 +1262,15 @@ function moodleoverflow_print_post($post, $discussion, $moodleoverflow, $cm, $co
         $link = '/mod/moodleoverflow/discussion.php';
         if ($post->markedsolution) {
             $commands[] = html_writer::tag('a', $str->marknotsolved,
-                    array('class' => 'marksolved onlyifreviewed', 'role' => 'button', 'data-moodleoverflow-action' => 'solved'));
+                    ['class' => 'marksolved onlyifreviewed', 'role' => 'button', 'data-moodleoverflow-action' => 'solved']);
         } else {
             // If there are already marked posts, change the string of the button.
             if ($solvedposts) {
                 $commands[] = html_writer::tag('a', $str->alsomarksolved,
-                    array('class' => 'marksolved onlyifreviewed', 'role' => 'button', 'data-moodleoverflow-action' => 'solved'));
+                    ['class' => 'marksolved onlyifreviewed', 'role' => 'button', 'data-moodleoverflow-action' => 'solved']);
             } else {
                 $commands[] = html_writer::tag('a', $str->marksolved,
-                    array('class' => 'marksolved onlyifreviewed', 'role' => 'button', 'data-moodleoverflow-action' => 'solved'));
+                    ['class' => 'marksolved onlyifreviewed', 'role' => 'button', 'data-moodleoverflow-action' => 'solved']);
             }
         }
     }
@@ -1283,8 +1283,8 @@ function moodleoverflow_print_post($post, $discussion, $moodleoverflow, $cm, $co
                     (!review::should_post_be_reviewed($post, $moodleoverflow) || !$post->reviewed))
         || capabilities::has(capabilities::EDIT_ANY_POST, $modulecontext)
     ) {
-        $editurl = new moodle_url('/mod/moodleoverflow/post.php', array('edit' => $post->id));
-        $commands[] = array('url' => $editurl, 'text' => $str->edit);
+        $editurl = new moodle_url('/mod/moodleoverflow/post.php', ['edit' => $post->id]);
+        $commands[] = ['url' => $editurl, 'text' => $str->edit];
     }
 
     // Give the option to delete a post.
@@ -1293,30 +1293,30 @@ function moodleoverflow_print_post($post, $discussion, $moodleoverflow, $cm, $co
         capabilities::has(capabilities::DELETE_ANY_POST, $modulecontext)) {
 
         $link = '/mod/moodleoverflow/post.php';
-        $commands[] = array('url' => new moodle_url($link, array('delete' => $post->id)), 'text' => $str->delete);
+        $commands[] = ['url' => new moodle_url($link, ['delete' => $post->id]), 'text' => $str->delete];
     }
 
     // Give the option to reply to a post.
     if (moodleoverflow_user_can_post($modulecontext, $post, false)) {
 
         $attributes = [
-                'class' => 'onlyifreviewed'
+                'class' => 'onlyifreviewed',
         ];
 
         // Answer to the parent post.
         if (empty($post->parent)) {
-            $replyurl = new moodle_url('/mod/moodleoverflow/post.php#mformmoodleoverflow', array('reply' => $post->id));
-            $commands[] = array('url' => $replyurl, 'text' => $str->replyfirst, 'attributes' => $attributes);
+            $replyurl = new moodle_url('/mod/moodleoverflow/post.php#mformmoodleoverflow', ['reply' => $post->id]);
+            $commands[] = ['url' => $replyurl, 'text' => $str->replyfirst, 'attributes' => $attributes];
 
             // If the post is a comment, answer to the parent post.
         } else if (!$iscomment) {
-            $replyurl = new moodle_url('/mod/moodleoverflow/post.php#mformmoodleoverflow', array('reply' => $post->id));
-            $commands[] = array('url' => $replyurl, 'text' => $str->reply, 'attributes' => $attributes);
+            $replyurl = new moodle_url('/mod/moodleoverflow/post.php#mformmoodleoverflow', ['reply' => $post->id]);
+            $commands[] = ['url' => $replyurl, 'text' => $str->reply, 'attributes' => $attributes];
 
             // Else simple respond to the answer.
         } else {
-            $replyurl = new moodle_url('/mod/moodleoverflow/post.php#mformmoodleoverflow', array('reply' => $iscomment));
-            $commands[] = array('url' => $replyurl, 'text' => $str->reply, 'attributes' => $attributes);
+            $replyurl = new moodle_url('/mod/moodleoverflow/post.php#mformmoodleoverflow', ['reply' => $iscomment]);
+            $commands[] = ['url' => $replyurl, 'text' => $str->reply, 'attributes' => $attributes];
         }
     }
 
@@ -1452,7 +1452,7 @@ function moodleoverflow_print_post($post, $discussion, $moodleoverflow, $cm, $co
     $mustachedata->attachments = get_attachments($post, $cm);
 
     // Output the commands.
-    $commandhtml = array();
+    $commandhtml = [];
     foreach ($commands as $command) {
         if (is_array($command)) {
             $commandhtml[] = html_writer::link($command['url'], $command['text'], $command['attributes'] ?? null);
@@ -1566,14 +1566,14 @@ function moodleoverflow_print_posts_nested($course, &$cm, $moodleoverflow, $disc
  */
 function get_attachments($post, $cm) {
     global $CFG, $OUTPUT;
-    $attachments = array();
+    $attachments = [];
 
     if (empty($post->attachment)) {
-        return array();
+        return [];
     }
 
     if (!$context = context_module::instance($cm->id)) {
-        return array();
+        return [];
     }
 
     $fs = get_file_storage();
@@ -1584,20 +1584,20 @@ function get_attachments($post, $cm) {
     if ($files) {
         $i = 0;
         foreach ($files as $file) {
-            $attachments[$i] = array();
+            $attachments[$i] = [];
             $attachments[$i]['filename'] = $file->get_filename();
 
             $mimetype = $file->get_mimetype();
             $iconimage = $OUTPUT->pix_icon(file_file_icon($file),
                 get_mimetype_description($file), 'moodle',
-                array('class' => 'icon'));
+                ['class' => 'icon']);
             $path = moodle_url::make_pluginfile_url($file->get_contextid(), $file->get_component(), $file->get_filearea(),
                                                      $file->get_itemid(), $file->get_filepath(), $file->get_filename());
 
             $attachments[$i]['icon'] = $iconimage;
             $attachments[$i]['filepath'] = $path;
 
-            if (in_array($mimetype, array('image/gif', 'image/jpeg', 'image/png'))) {
+            if (in_array($mimetype, ['image/gif', 'image/jpeg', 'image/png'])) {
                 // Image attachments don't get printed as links.
                 $attachments[$i]['image'] = true;
             } else {
@@ -1632,7 +1632,7 @@ function moodleoverflow_add_attachment($post, $forum, $cm) {
     file_save_draft_area_files($post->attachments, $context->id, 'mod_moodleoverflow', 'attachment', $post->id,
         mod_moodleoverflow_post_form::attachment_options($forum));
 
-    $DB->set_field('moodleoverflow_posts', 'attachment', $present, array('id' => $post->id));
+    $DB->set_field('moodleoverflow_posts', 'attachment', $present, ['id' => $post->id]);
 
     return true;
 }
@@ -1649,8 +1649,8 @@ function moodleoverflow_add_new_post($post) {
 
     // We do not check if these variables exist because this function
     // is just called from one function which checks all these variables.
-    $discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $post->discussion));
-    $moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $discussion->moodleoverflow));
+    $discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $post->discussion]);
+    $moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $discussion->moodleoverflow]);
     $cm = get_coursemodule_from_instance('moodleoverflow', $moodleoverflow->id);
 
     // Add some variables to the post.
@@ -1670,13 +1670,13 @@ function moodleoverflow_add_new_post($post) {
 
     // Add the post to the database.
     $post->id = $DB->insert_record('moodleoverflow_posts', $post);
-    $DB->set_field('moodleoverflow_posts', 'message', $post->message, array('id' => $post->id));
+    $DB->set_field('moodleoverflow_posts', 'message', $post->message, ['id' => $post->id]);
     moodleoverflow_add_attachment($post, $moodleoverflow, $cm);
 
     if ($post->reviewed) {
         // Update the discussion.
-        $DB->set_field('moodleoverflow_discussions', 'timemodified', $post->modified, array('id' => $post->discussion));
-        $DB->set_field('moodleoverflow_discussions', 'usermodified', $post->userid, array('id' => $post->discussion));
+        $DB->set_field('moodleoverflow_discussions', 'timemodified', $post->modified, ['id' => $post->discussion]);
+        $DB->set_field('moodleoverflow_discussions', 'usermodified', $post->userid, ['id' => $post->discussion]);
     }
 
     // Mark the created post as read if the user is tracking the discussion.
@@ -1703,9 +1703,9 @@ function moodleoverflow_update_post($newpost) {
     global $DB, $USER;
 
     // Retrieve not submitted variables.
-    $post = $DB->get_record('moodleoverflow_posts', array('id' => $newpost->id));
-    $discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $post->discussion));
-    $moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $discussion->moodleoverflow));
+    $post = $DB->get_record('moodleoverflow_posts', ['id' => $newpost->id]);
+    $discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $post->discussion]);
+    $moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $discussion->moodleoverflow]);
 
     // Allowed modifiable fields.
     $modifiablefields = [
@@ -1788,7 +1788,7 @@ function moodleoverflow_delete_discussion($discussion, $course, $cm, $moodleover
     $result = true;
 
     // Get all posts related to the discussion.
-    if ($posts = $DB->get_records('moodleoverflow_posts', array('discussion' => $discussion->id))) {
+    if ($posts = $DB->get_records('moodleoverflow_posts', ['discussion' => $discussion->id])) {
 
         // Iterate through them and delete each one.
         foreach ($posts as $post) {
@@ -1806,8 +1806,8 @@ function moodleoverflow_delete_discussion($discussion, $course, $cm, $moodleover
     readtracking::moodleoverflow_delete_read_records(-1, -1, $discussion->id);
 
     // Remove the subscriptions for this discussion.
-    $DB->delete_records('moodleoverflow_discuss_subs', array('discussion' => $discussion->id));
-    if (!$DB->delete_records('moodleoverflow_discussions', array('id' => $discussion->id))) {
+    $DB->delete_records('moodleoverflow_discuss_subs', ['discussion' => $discussion->id]);
+    if (!$DB->delete_records('moodleoverflow_discussions', ['id' => $discussion->id])) {
         $result = false;
     }
 
@@ -1834,7 +1834,7 @@ function moodleoverflow_delete_post($post, $deletechildren, $cm, $moodleoverflow
     try {
         $transaction = $DB->start_delegated_transaction();
 
-        $childposts = $DB->get_records('moodleoverflow_posts', array('parent' => $post->id));
+        $childposts = $DB->get_records('moodleoverflow_posts', ['parent' => $post->id]);
         if ($deletechildren && $childposts) {
             foreach ($childposts as $childpost) {
                 moodleoverflow_delete_post($childpost, true, $cm, $moodleoverflow);
@@ -1842,10 +1842,10 @@ function moodleoverflow_delete_post($post, $deletechildren, $cm, $moodleoverflow
         }
 
         // Delete the ratings.
-        $DB->delete_records('moodleoverflow_ratings', array('postid' => $post->id));
+        $DB->delete_records('moodleoverflow_ratings', ['postid' => $post->id]);
 
         // Delete the post.
-        if ($DB->delete_records('moodleoverflow_posts', array('id' => $post->id))) {
+        if ($DB->delete_records('moodleoverflow_posts', ['id' => $post->id])) {
             // Delete the read records.
             readtracking::moodleoverflow_delete_read_records(-1, $post->id);
 
@@ -1872,14 +1872,14 @@ function moodleoverflow_delete_post($post, $deletechildren, $cm, $moodleoverflow
             $modulecontext = context_module::instance($cm->id);
 
             // Trigger the post deletion event.
-            $params = array(
+            $params = [
                 'context' => $modulecontext,
                 'objectid' => $post->id,
-                'other' => array(
+                'other' => [
                     'discussionid' => $post->discussion,
-                    'moodleoverflowid' => $moodleoverflow->id
-                )
-            );
+                    'moodleoverflowid' => $moodleoverflow->id,
+                ],
+            ];
             if ($post->userid !== $USER->id) {
                 $params['relateduserid'] = $post->userid;
             }
@@ -1909,7 +1909,7 @@ function moodleoverflow_discussion_update_last_post($discussionid) {
     global $DB;
 
     // Check if the given discussion exists.
-    if (!$DB->record_exists('moodleoverflow_discussions', array('id' => $discussionid))) {
+    if (!$DB->record_exists('moodleoverflow_discussions', ['id' => $discussionid])) {
         return false;
     }
 
@@ -1921,7 +1921,7 @@ function moodleoverflow_discussion_update_last_post($discussionid) {
           ORDER BY modified DESC";
 
     // Find the new last post of the discussion.
-    if (($lastposts = $DB->get_records_sql($sql, array($discussionid), 0, 1))) {
+    if (($lastposts = $DB->get_records_sql($sql, [$discussionid], 0, 1))) {
         $lastpost = reset($lastposts);
 
         // Create an discussion object.
@@ -1969,10 +1969,10 @@ function moodleoverflow_count_discussions($moodleoverflow, $course) {
     global $CFG, $DB;
 
     // Create a cache.
-    static $cache = array();
+    static $cache = [];
 
     // Initiate variables.
-    $params = array($course->id);
+    $params = [$course->id];
 
     // Check whether the cache for the moodleoverflow is set.
     if (!isset($cache[$course->id])) {
@@ -2000,7 +2000,7 @@ function moodleoverflow_count_discussions($moodleoverflow, $course) {
             // There are no records.
 
             // Save the result into the cache.
-            $cache[$course->id] = array();
+            $cache[$course->id] = [];
         }
     }
 
@@ -2016,7 +2016,7 @@ function moodleoverflow_count_discussions($moodleoverflow, $course) {
     $sql = "SELECT COUNT(d.id)
             FROM {moodleoverflow_discussions} d
             WHERE d.moodleoverflow = ?";
-    $amount = $DB->get_field_sql($sql, array($moodleoverflow->id));
+    $amount = $DB->get_field_sql($sql, [$moodleoverflow->id]);
 
     // Return the amount.
     return $amount;
@@ -2058,10 +2058,10 @@ function moodleoverflow_update_user_grade_on_db($moodleoverflow, $postuserrating
     }
 
     // Save updated grade on local table.
-    if ($DB->record_exists('moodleoverflow_grades', array('userid' => $userid, 'moodleoverflowid' => $moodleoverflow->id))) {
+    if ($DB->record_exists('moodleoverflow_grades', ['userid' => $userid, 'moodleoverflowid' => $moodleoverflow->id])) {
 
-        $DB->set_field('moodleoverflow_grades', 'grade', $grade, array('userid' => $userid,
-            'moodleoverflowid' => $moodleoverflow->id));
+        $DB->set_field('moodleoverflow_grades', 'grade', $grade, ['userid' => $userid,
+            'moodleoverflowid' => $moodleoverflow->id]);
 
     } else {
 
@@ -2085,7 +2085,7 @@ function moodleoverflow_update_user_grade_on_db($moodleoverflow, $postuserrating
 function moodleoverflow_update_all_grades_for_cm($moodleoverflowid) {
     global $DB;
 
-    $moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $moodleoverflowid));
+    $moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflowid]);
 
     // Check whether moodleoverflow object has the added params.
     if ($moodleoverflow->grademaxgrade > 0 && $moodleoverflow->gradescalefactor > 0) {

--- a/locallib.php
+++ b/locallib.php
@@ -928,8 +928,12 @@ function moodleoverflow_print_discussion($course, $cm, $moodleoverflow, $discuss
 
     // Retrieve all posts of the discussion.
     $posts = moodleoverflow_get_all_discussion_posts($discussion->id, $istracked, $modulecontext);
-
-    $usermapping = anonymous::get_userid_mapping($moodleoverflow, $discussion->id);
+    /*$newpost = [];
+    foreach($posts as $posti) {
+        $newpost[] = $posti->message;
+    }
+    var_dump($newpost);
+    */$usermapping = anonymous::get_userid_mapping($moodleoverflow, $discussion->id);
 
     // Start with the parent post.
     $post = $posts[$post->id];

--- a/markposts.php
+++ b/markposts.php
@@ -32,7 +32,7 @@ $discussionid = optional_param('d', 0, PARAM_INT);      // The discussion to mar
 $returndiscussion = optional_param('return', 0, PARAM_INT); // The page to return to.
 
 // Prepare the array that should be used to return to this page.
-$url = new moodle_url('/mod/moodleoverflow/markposts.php', array('m' => $moodleoverflowid));
+$url = new moodle_url('/mod/moodleoverflow/markposts.php', ['m' => $moodleoverflowid]);
 
 // Check the optional params.
 if ($discussionid !== 0) {
@@ -46,12 +46,12 @@ if ($returndiscussion !== 0) {
 $PAGE->set_url($url);
 
 // Retrieve the connected moodleoverflow instance.
-if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $moodleoverflowid))) {
+if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflowid])) {
     throw new moodle_exception('invalidmoodleoverflowid', 'moodleoverflow');
 }
 
 // Retrieve the connected course.
-if (!$course = $DB->get_record('course', array('id' => $moodleoverflow->course))) {
+if (!$course = $DB->get_record('course', ['id' => $moodleoverflow->course])) {
     throw new moodle_exception('invalidcourseid');
 }
 
@@ -70,12 +70,12 @@ require_login($course, false, $cm);
 if ($returndiscussion === 0) {
 
     // If no parameter is set, relink to the view.
-    $returnto = new moodle_url("/mod/moodleoverflow/view.php", array('m' => $moodleoverflow->id));
+    $returnto = new moodle_url("/mod/moodleoverflow/view.php", ['m' => $moodleoverflow->id]);
 
 } else {
 
     // Else relink back to the discussion we are coming from.
-    $returnto = new moodle_url("/mod/moodleoverflow/discussion.php", array('d' => $returndiscussion));
+    $returnto = new moodle_url("/mod/moodleoverflow/discussion.php", ['d' => $returndiscussion]);
 }
 
 // Guests can't mark posts as read.
@@ -99,7 +99,7 @@ if (isguestuser()) {
 if (!empty($discussionid)) {
 
     // Check if the discussion exists.
-    $options = array('id' => $discussionid, 'moodleoverflow' => $moodleoverflow->id);
+    $options = ['id' => $discussionid, 'moodleoverflow' => $moodleoverflow->id];
     $discussion = $DB->get_record('moodleoverflow_discussions', $options);
     if (!$discussion) {
         throw new moodle_exception('invaliddiscussionid', 'moodleoverflow');

--- a/mod_form.php
+++ b/mod_form.php
@@ -59,7 +59,7 @@ class mod_moodleoverflow_mod_form extends moodleform_mod {
         $mform->addElement('header', 'general', get_string('general', 'form'));
 
         // Adding the standard "name" field.
-        $mform->addElement('text', 'name', get_string('moodleoverflowname', 'moodleoverflow'), array('size' => '64'));
+        $mform->addElement('text', 'name', get_string('moodleoverflowname', 'moodleoverflow'), ['size' => '64']);
         if (!empty(get_config('moodleoverflow', 'formatstringstriptags'))) {
             $mform->setType('name', PARAM_TEXT);
         } else {
@@ -77,7 +77,7 @@ class mod_moodleoverflow_mod_form extends moodleform_mod {
 
         $currentsetting = $this->current && property_exists($this->current, 'anonymous') ? $this->current->anonymous : 0;
         $possiblesettings = [
-                anonymous::EVERYTHING_ANONYMOUS => get_string('anonymous:everything', 'moodleoverflow')
+                anonymous::EVERYTHING_ANONYMOUS => get_string('anonymous:everything', 'moodleoverflow'),
         ];
 
         if ($currentsetting <= anonymous::QUESTION_ANONYMOUS) {
@@ -98,7 +98,7 @@ class mod_moodleoverflow_mod_form extends moodleform_mod {
             $possiblesettings = [
                     review::NOTHING => get_string('nothing', 'moodleoverflow'),
                     review::QUESTIONS => get_string('questions', 'moodleoverflow'),
-                    review::EVERYTHING => get_string('questions_and_posts', 'moodleoverflow')
+                    review::EVERYTHING => get_string('questions_and_posts', 'moodleoverflow'),
             ];
 
             $mform->addElement('select', 'needsreview', get_string('review', 'moodleoverflow'), $possiblesettings);
@@ -115,7 +115,7 @@ class mod_moodleoverflow_mod_form extends moodleform_mod {
         $mform->addHelpButton('maxbytes', 'maxattachmentsize', 'moodleoverflow');
         $mform->setDefault('maxbytes', get_config('moodleoverflow', 'maxbytes'));
 
-        $choices = array(
+        $choices = [
             0 => 0,
             1 => 1,
             2 => 2,
@@ -129,8 +129,8 @@ class mod_moodleoverflow_mod_form extends moodleform_mod {
             10 => 10,
             20 => 20,
             50 => 50,
-            100 => 100
-        );
+            100 => 100,
+        ];
         $mform->addElement('select', 'maxattachments', get_string('maxattachments', 'moodleoverflow'), $choices);
         $mform->addHelpButton('maxattachments', 'maxattachments', 'moodleoverflow');
         $mform->setDefault('maxattachments', get_config('moodleoverflow', 'maxattachments'));
@@ -139,7 +139,7 @@ class mod_moodleoverflow_mod_form extends moodleform_mod {
         $mform->addElement('header', 'subscriptiontrackingheader', get_string('subscriptiontrackingheader', 'moodleoverflow'));
 
         // Prepare the array with options for the subscription state.
-        $options = array();
+        $options = [];
         $options[MOODLEOVERFLOW_CHOOSESUBSCRIBE] = get_string('subscriptionoptional', 'moodleoverflow');
         $options[MOODLEOVERFLOW_FORCESUBSCRIBE] = get_string('subscriptionforced', 'moodleoverflow');
         $options[MOODLEOVERFLOW_INITIALSUBSCRIBE] = get_string('subscriptionauto', 'moodleoverflow');
@@ -150,7 +150,7 @@ class mod_moodleoverflow_mod_form extends moodleform_mod {
         $mform->addHelpButton('forcesubscribe', 'subscriptionmode', 'moodleoverflow');
 
         // Set the options for the default readtracking.
-        $options = array();
+        $options = [];
         $options[MOODLEOVERFLOW_TRACKING_OPTIONAL] = get_string('trackingoptional', 'moodleoverflow');
         $options[MOODLEOVERFLOW_TRACKING_OFF] = get_string('trackingoff', 'moodleoverflow');
         if (get_config('moodleoverflow', 'allowforcedreadtracking')) {
@@ -194,7 +194,7 @@ class mod_moodleoverflow_mod_form extends moodleform_mod {
         $mform->addElement('header', 'ratingheading', get_string('ratingheading', 'moodleoverflow'));
 
         // Which rating is more important?
-        $options = array();
+        $options = [];
         $options[MOODLEOVERFLOW_PREFERENCE_STARTER] = get_string('starterrating', 'moodleoverflow');
         $options[MOODLEOVERFLOW_PREFERENCE_TEACHER] = get_string('teacherrating', 'moodleoverflow');
         $mform->addElement('select', 'ratingpreference', get_string('ratingpreference', 'moodleoverflow'), $options);

--- a/post.php
+++ b/post.php
@@ -50,16 +50,16 @@ if ($count !== 1) {
 }
 
 // Set the URL that should be used to return to this page.
-$PAGE->set_url('/mod/moodleoverflow/post.php', array(
+$PAGE->set_url('/mod/moodleoverflow/post.php', [
     'moodleoverflow' => $moodleoverflow,
     'reply' => $reply,
     'edit' => $edit,
     'delete' => $delete,
     'confirm' => $confirm,
-));
+]);
 
 // These params will be passed as hidden variables later in the form.
-$pageparams = array('moodleoverflow' => $moodleoverflow, 'reply' => $reply, 'edit' => $edit);
+$pageparams = ['moodleoverflow' => $moodleoverflow, 'reply' => $reply, 'edit' => $edit];
 
 // Get the system context instance.
 $systemcontext = context_system::instance();
@@ -71,7 +71,7 @@ if (!isloggedin() || isguestuser()) {
     if (!empty($moodleoverflow)) {
 
         // Check the moodleoverflow instance is valid.
-        if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $moodleoverflow))) {
+        if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflow])) {
             throw new moodle_exception('invalidmoodleoverflowid', 'moodleoverflow');
         }
 
@@ -84,18 +84,18 @@ if (!isloggedin() || isguestuser()) {
         }
 
         // Check if the post is part of a valid discussion.
-        if (!$discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $parent->discussion))) {
+        if (!$discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $parent->discussion])) {
             throw new moodle_exception('notpartofdiscussion', 'moodleoverflow');
         }
 
         // Check if the post is related to a valid moodleoverflow instance.
-        if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $discussion->moodleoverflow))) {
+        if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $discussion->moodleoverflow])) {
             throw new moodle_exception('invalidmoodleoverflowid', 'moodleoverflow');
         }
     }
 
     // Get the related course.
-    if (!$course = $DB->get_record('course', array('id' => $moodleoverflow->course))) {
+    if (!$course = $DB->get_record('course', ['id' => $moodleoverflow->course])) {
         throw new moodle_exception('invalidcourseid');
     }
 
@@ -131,12 +131,12 @@ require_login(0, false);
 if (!empty($moodleoverflow)) {
 
     // Check the moodleoverflow instance is valid.
-    if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $moodleoverflow))) {
+    if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflow])) {
         throw new moodle_exception('invalidmoodleoverflowid', 'moodleoverflow');
     }
 
     // Get the related course.
-    if (!$course = $DB->get_record('course', array('id' => $moodleoverflow->course))) {
+    if (!$course = $DB->get_record('course', ['id' => $moodleoverflow->course])) {
         throw new moodle_exception('invalidcourseid');
     }
 
@@ -157,10 +157,10 @@ if (!empty($moodleoverflow)) {
             if (enrol_selfenrol_available($course->id)) {
                 $SESSION->wantsurl = qualified_me();
                 $SESSION->enrolcancel = get_local_referer(false);
-                redirect(new moodle_url('/enrol/index.php', array(
+                redirect(new moodle_url('/enrol/index.php', [
                     'id' => $course->id,
-                    'returnurl' => '/mod/moodleoverflow/view.php?m=' . $moodleoverflow->id
-                )), get_string('youneedtoenrol'));
+                    'returnurl' => '/mod/moodleoverflow/view.php?m=' . $moodleoverflow->id,
+                ]), get_string('youneedtoenrol'));
             }
         }
 
@@ -194,17 +194,17 @@ if (!empty($moodleoverflow)) {
     }
 
     // Check if the post is part of a discussion.
-    if (!$discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $parent->discussion))) {
+    if (!$discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $parent->discussion])) {
         throw new moodle_exception('notpartofdiscussion', 'moodleoverflow');
     }
 
     // Check if the discussion is part of a moodleoverflow instance.
-    if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $discussion->moodleoverflow))) {
+    if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $discussion->moodleoverflow])) {
         throw new moodle_exception('invalidmoodleoverflowid', 'moodleoverflow');
     }
 
     // Check if the moodleoverflow instance is part of a course.
-    if (!$course = $DB->get_record('course', array('id' => $discussion->course))) {
+    if (!$course = $DB->get_record('course', ['id' => $discussion->course])) {
         throw new moodle_exception('invalidcourseid');
     }
 
@@ -228,7 +228,7 @@ if (!empty($moodleoverflow)) {
             $SESSION->wantsurl = qualified_me();
             $SESSION->enrolcancel = get_local_referer(false);
             redirect(new moodle_url('/enrol/index.php',
-                array('id' => $course->id, 'returnurl' => '/mod/moodleoverflow/view.php?m=' . $moodleoverflow->id)),
+                ['id' => $course->id, 'returnurl' => '/mod/moodleoverflow/view.php?m=' . $moodleoverflow->id]),
                 get_string('youneedtoenrol'));
         }
 
@@ -278,17 +278,17 @@ if (!empty($moodleoverflow)) {
     }
 
     // Check if the post refers to a valid discussion.
-    if (!$discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $post->discussion))) {
+    if (!$discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $post->discussion])) {
         throw new moodle_exception('notpartofdiscussion', 'moodleoverflow');
     }
 
     // Check if the post refers to a valid moodleoverflow instance.
-    if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $discussion->moodleoverflow))) {
+    if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $discussion->moodleoverflow])) {
         throw new moodle_exception('invalidmoodleoverflowid', 'moodleoverflow');
     }
 
     // Check if the post refers to a valid course.
-    if (!$course = $DB->get_record('course', array('id' => $discussion->course))) {
+    if (!$course = $DB->get_record('course', ['id' => $discussion->course])) {
         throw new moodle_exception('invalidcourseid');
     }
 
@@ -340,12 +340,12 @@ if (!empty($moodleoverflow)) {
     }
 
     // Get the related discussion.
-    if (!$discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $post->discussion))) {
+    if (!$discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $post->discussion])) {
         throw new moodle_exception('notpartofdiscussion', 'moodleoverflow');
     }
 
     // Get the related moodleoverflow instance.
-    if (!$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $discussion->moodleoverflow))) {
+    if (!$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $discussion->moodleoverflow])) {
         throw new moodle_exception('invalidmoodleoverflowid', 'moodleoveflow');
     }
 
@@ -355,7 +355,7 @@ if (!empty($moodleoverflow)) {
     }
 
     // Get the related course.
-    if (!$course = $DB->get_record('course', array('id' => $moodleoverflow->course))) {
+    if (!$course = $DB->get_record('course', ['id' => $moodleoverflow->course])) {
         throw new moodle_exception('invalidcourseid');
     }
 
@@ -379,13 +379,13 @@ if (!empty($moodleoverflow)) {
         // Check if the user has the capability to delete the post.
         $timepassed = time() - $post->created;
         if (($timepassed > get_config('moodleoverflow', 'maxeditingtime')) && !$deleteanypost) {
-            $url = new moodle_url('/mod/moodleoverflow/discussion.php', array('d' => $post->discussion));
+            $url = new moodle_url('/mod/moodleoverflow/discussion.php', ['d' => $post->discussion]);
             throw new moodle_exception('cannotdeletepost', 'moodleoverflow', moodleoverflow_go_back_to($url));
         }
 
         // A normal user cannot delete his post if there are direct replies.
         if ($replycount && !$deleteanypost) {
-            $url = new moodle_url('/mod/moodleoverflow/discussion.php', array('d' => $post->discussion));
+            $url = new moodle_url('/mod/moodleoverflow/discussion.php', ['d' => $post->discussion]);
             throw new moodle_exception('couldnotdeletereplies', 'moodleoverflow', moodleoverflow_go_back_to($url));
         } else {
             // Delete the post.
@@ -395,10 +395,10 @@ if (!empty($moodleoverflow)) {
                 moodleoverflow_delete_discussion($discussion, $course, $cm, $moodleoverflow);
 
                 // Trigger the discussion deleted event.
-                $params = array(
+                $params = [
                     'objectid' => $discussion->id,
                     'context' => $modulecontext,
-                );
+                ];
 
                 $event = \mod_moodleoverflow\event\discussion_deleted::create($params);
                 $event->trigger();
@@ -410,7 +410,7 @@ if (!empty($moodleoverflow)) {
             } else if (moodleoverflow_delete_post($post, $deleteanypost, $cm, $moodleoverflow)) {
                 // Delete a single post.
                 // Redirect back to the discussion.
-                $discussionurl = new moodle_url('/mod/moodleoverflow/discussion.php', array('d' => $discussion->id));
+                $discussionurl = new moodle_url('/mod/moodleoverflow/discussion.php', ['d' => $discussion->id]);
                 redirect(moodleoverflow_go_back_to($discussionurl));
                 exit;
 
@@ -437,7 +437,7 @@ if (!empty($moodleoverflow)) {
             if (!$deleteanypost) {
                 throw new moodle_exception('couldnotdeletereplies', 'moodleoverflow',
                     moodleoverflow_go_back_to(new moodle_url('/mod/moodleoverflow/discussion.php',
-                        array('d' => $post->discussion, 'p' . $post->id))));
+                        ['d' => $post->discussion, 'p' . $post->id])));
             }
 
             // Request a confirmation to delete the post.
@@ -491,7 +491,7 @@ file_prepare_draft_area($draftitemid,
     mod_moodleoverflow_post_form::attachment_options($moodleoverflow));
 
 // Prepare the form.
-$formarray = array(
+$formarray = [
     'course' => $course,
     'cm' => $cm,
     'coursecontext' => $coursecontext,
@@ -499,8 +499,8 @@ $formarray = array(
     'moodleoverflow' => $moodleoverflow,
     'post' => $post,
     'edit' => $edit,
-);
-$mformpost = new mod_moodleoverflow_post_form('post.php', $formarray, 'post', '', array('id' => 'mformmoodleoverflow'));
+];
+$mformpost = new mod_moodleoverflow_post_form('post.php', $formarray, 'post', '', ['id' => 'mformmoodleoverflow']);
 
 // The current user is not the original author.
 // Append the message to the end of the message.
@@ -540,34 +540,34 @@ $postmessage = empty($post->message) ? null : $post->message;
 
 // Set data for the form.
 // TODO Refactor.
-$param1 = (isset($discussion->id) ? array($discussion->id) : array());
-$param2 = (isset($post->format) ? array('format' => $post->format) : array());
-$param3 = (isset($discussion->timestart) ? array('timestart' => $discussion->timestart) : array());
-$param4 = (isset($discussion->timeend) ? array('timeend' => $discussion->timeend) : array());
-$param5 = (isset($discussion->id) ? array('discussion' => $discussion->id) : array());
-$mformpost->set_data(array(
+$param1 = (isset($discussion->id) ? [$discussion->id] : []);
+$param2 = (isset($post->format) ? ['format' => $post->format] : []);
+$param3 = (isset($discussion->timestart) ? ['timestart' => $discussion->timestart] : []);
+$param4 = (isset($discussion->timeend) ? ['timeend' => $discussion->timeend] : []);
+$param5 = (isset($discussion->id) ? ['discussion' => $discussion->id] : []);
+$mformpost->set_data([
         'attachments' => $draftitemid,
         'general' => $heading,
         'subject' => $subject,
-        'message' => array(
+        'message' => [
             'text' => $postmessage,
             'format' => editors_get_preferred_format(),
             'itemid' => $postid,
-        ),
+        ],
         'userid' => $post->userid,
         'parent' => $post->parent,
         'discussion' => $post->discussion,
-        'course' => $course->id
-    ) + $pageparams + $param1 + $param2 + $param3 + $param4 + $param5);
+        'course' => $course->id,
+    ] + $pageparams + $param1 + $param2 + $param3 + $param4 + $param5);
 
 // Is it canceled?
 if ($mformpost->is_cancelled()) {
 
     // Redirect the user back.
     if (!isset($discussion->id)) {
-        redirect(new moodle_url('/mod/moodleoverflow/view.php', array('m' => $moodleoverflow->id)));
+        redirect(new moodle_url('/mod/moodleoverflow/view.php', ['m' => $moodleoverflow->id]));
     } else {
-        redirect(new moodle_url('/mod/moodleoverflow/discussion.php', array('d' => $discussion->id)));
+        redirect(new moodle_url('/mod/moodleoverflow/discussion.php', ['d' => $discussion->id]));
     }
 
     // Cancel.
@@ -599,7 +599,7 @@ if ($fromform = $mformpost->get_data()) {
 
         // The FORUM-Plugin had an bug: https://tracker.moodle.org/browse/MDL-4314
         // This is a fix for it.
-        if (!$realpost = $DB->get_record('moodleoverflow_posts', array('id' => $fromform->id))) {
+        if (!$realpost = $DB->get_record('moodleoverflow_posts', ['id' => $fromform->id])) {
             $realpost = new stdClass();
             $realpost->userid = -1;
         }
@@ -629,23 +629,23 @@ if ($fromform = $mformpost->get_data()) {
             if (\mod_moodleoverflow\anonymous::is_post_anonymous($discussion, $moodleoverflow, $realpost->userid)) {
                 $name = get_string('anonymous', 'moodleoverflow');
             } else {
-                $realuser = $DB->get_record('user', array('id' => $realpost->userid));
+                $realuser = $DB->get_record('user', ['id' => $realpost->userid]);
                 $name = fullname($realuser);
             }
             $message .= get_string('editedpostupdated', 'moodleoverflow', $name);
         }
 
         // Create a link to go back to the discussion.
-        $discussionurl = new moodle_url('/mod/moodleoverflow/discussion.php', array('d' => $discussion->id), 'p' . $fromform->id);
+        $discussionurl = new moodle_url('/mod/moodleoverflow/discussion.php', ['d' => $discussion->id], 'p' . $fromform->id);
 
         // Set some parameters.
-        $params = array(
+        $params = [
             'context' => $modulecontext,
             'objectid' => $fromform->id,
-            'other' => array(
+            'other' => [
                 'discussionid' => $discussion->id,
                 'moodleoverflowid' => $moodleoverflow->id,
-            ));
+            ]];
 
         // If the editing user is not the original author, add the original author to the params.
         if ($realpost->userid != $USER->id) {
@@ -688,16 +688,16 @@ if ($fromform = $mformpost->get_data()) {
 
             // Set the URL that links back to the discussion.
             $link = '/mod/moodleoverflow/discussion.php';
-            $discussionurl = new moodle_url($link, array('d' => $discussion->id), 'p' . $fromform->id);
+            $discussionurl = new moodle_url($link, ['d' => $discussion->id], 'p' . $fromform->id);
 
             // Trigger post created event.
-            $params = array(
+            $params = [
                 'context' => $modulecontext,
                 'objectid' => $fromform->id,
-                'other' => array(
+                'other' => [
                     'discussionid' => $discussion->id,
                     'moodleoverflowid' => $moodleoverflow->id,
-                ));
+                ]];
             $event = \mod_moodleoverflow\event\post_created::create($params);
             $event->trigger();
             redirect(
@@ -718,7 +718,7 @@ if ($fromform = $mformpost->get_data()) {
         // Add a new discussion.
 
         // The location to redirect the user after successfully posting.
-        $redirectto = new moodle_url('view.php', array('m' => $fromform->moodleoverflow));
+        $redirectto = new moodle_url('view.php', ['m' => $fromform->moodleoverflow]);
 
         $discussion = $fromform;
         $discussion->name = $fromform->subject;
@@ -735,21 +735,21 @@ if ($fromform = $mformpost->get_data()) {
 
         } else {    // The creation of the new discussion was successful.
 
-            $params = array(
+            $params = [
                 'context' => $modulecontext,
                 'objectid' => $discussion->id,
-                'other' => array(
+                'other' => [
                     'moodleoverflowid' => $moodleoverflow->id,
-                )
-            );
+                ],
+            ];
 
             $message = '<p>' . get_string("postaddedsuccess", "moodleoverflow") . '</p>';
 
             // Trigger the discussion created event.
-            $params = array(
+            $params = [
                 'context' => $modulecontext,
                 'objectid' => $discussion->id,
-            );
+            ];
             $event = \mod_moodleoverflow\event\discussion_created::create($params);
             $event->trigger();
             // Subscribe to this thread.

--- a/settings.php
+++ b/settings.php
@@ -50,7 +50,7 @@ if ($ADMIN->fulltree) {
 
 
     // Default read tracking settings.
-    $options = array();
+    $options = [];
     $options[MOODLEOVERFLOW_TRACKING_OPTIONAL] = get_string('trackingoptional', 'moodleoverflow');
     $options[MOODLEOVERFLOW_TRACKING_OFF] = get_string('trackingoff', 'moodleoverflow');
     $options[MOODLEOVERFLOW_TRACKING_FORCED] = get_string('trackingon', 'moodleoverflow');
@@ -70,7 +70,7 @@ if ($ADMIN->fulltree) {
         get_string('configoldpostdays', 'moodleoverflow'), 14, PARAM_INT));
 
     // Default time (hour) to execute 'clean_read_records' cron.
-    $options = array();
+    $options = [];
     for ($i = 0; $i < 24; $i++) {
         $options[$i] = sprintf("%02d", $i);
     }

--- a/subscribe.php
+++ b/subscribe.php
@@ -38,7 +38,7 @@ $sesskey = optional_param('sesskey', null, PARAM_RAW);
 $returnurl = optional_param('returnurl', null, PARAM_RAW);
 
 // Set the url to return to the same action.
-$url = new moodle_url('/mod/moodleoverflow/subscribe.php', array('id' => $id));
+$url = new moodle_url('/mod/moodleoverflow/subscribe.php', ['id' => $id]);
 if (!is_null($mode)) {
     $url->param('mode', $mode);
 }
@@ -50,7 +50,7 @@ if (!is_null($sesskey)) {
 }
 if (!is_null($discussionid)) {
     $url->param('d', $discussionid);
-    if (!$discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $discussionid, 'moodleoverflow' => $id))) {
+    if (!$discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $discussionid, 'moodleoverflow' => $id])) {
         throw new moodle_exception('invaliddiscussionid', 'moodleoverflow');
     }
 }
@@ -59,16 +59,16 @@ if (!is_null($discussionid)) {
 $PAGE->set_url($url);
 
 // Get all necessary objects.
-$moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $id), '*', MUST_EXIST);
-$course = $DB->get_record('course', array('id' => $moodleoverflow->course), '*', MUST_EXIST);
+$moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $id], '*', MUST_EXIST);
+$course = $DB->get_record('course', ['id' => $moodleoverflow->course], '*', MUST_EXIST);
 $cm = get_coursemodule_from_instance('moodleoverflow', $moodleoverflow->id, $course->id, false, MUST_EXIST);
 $context = context_module::instance($cm->id);
 
 // Define variables.
-$notify = array();
+$notify = [];
 $notify['success'] = \core\output\notification::NOTIFY_SUCCESS;
 $notify['error'] = \core\output\notification::NOTIFY_ERROR;
-$strings = array();
+$strings = [];
 $strings['subscribeenrolledonly'] = get_string('subscribeenrolledonly', 'moodleoverflow');
 $strings['everyonecannowchoose'] = get_string('everyonecannowchoose', 'moodleoverflow');
 $strings['everyoneisnowsubscribed'] = get_string('everyoneisnowsubscribed', 'moodleoverflow');
@@ -88,7 +88,7 @@ if ($user) {
     }
 
     // Retrieve the user from the database.
-    $user = $DB->get_record('user', array('id' => $user), '*', MUST_EXIST);
+    $user = $DB->get_record('user', ['id' => $user], '*', MUST_EXIST);
 
 } else {
 
@@ -114,13 +114,13 @@ if (is_null($mode) && !$isenrolled) {
     if (isguestuser()) {
         echo $OUTPUT->header();
         $message = $strings['subscribeenrolledonly'] . '<br /></ br>' . get_string('liketologin');
-        $url = new moodle_url('/mod/moodleoverflow/view.php', array('m' => $id));
+        $url = new moodle_url('/mod/moodleoverflow/view.php', ['m' => $id]);
         echo $OUTPUT->confirm($message, get_login_url(), $url);
         echo $OUTPUT->footer;
         exit;
     } else {
         // There should not be any links leading to this place. Just redirect.
-        $url = new moodle_url('/mod/moodleoverflow/view.php', array('m' => $id));
+        $url = new moodle_url('/mod/moodleoverflow/view.php', ['m' => $id]);
         redirect($url, $strings['subscribeenrolledonly'], null, $notify['error']);
     }
 }
@@ -207,7 +207,7 @@ if ($issubscribed) {
         echo $OUTPUT->header();
 
         // Create an url to get back to the view.
-        $viewurl = new moodle_url('/mod/moodleoverflow/view.php', array('m' => $id));
+        $viewurl = new moodle_url('/mod/moodleoverflow/view.php', ['m' => $id]);
 
         // Was a discussion id submitted?
         if ($discussionid) {
@@ -262,7 +262,7 @@ if ($issubscribed) {
     // The user needs to be subscribed.
 
     // Check the capabilities.
-    $capabilities = array();
+    $capabilities = [];
     $capabilities['managesubscriptions'] = has_capability('mod/moodleoverflow:managesubscriptions', $context);
     $capabilities['viewdiscussion'] = has_capability('mod/moodleoverflow:viewdiscussion', $context);
     require_sesskey();
@@ -287,7 +287,7 @@ if ($issubscribed) {
         echo $OUTPUT->header();
 
         // Create the url to redirect the user back to.
-        $viewurl = new moodle_url('/mod/moodleoverflow/view.php', array('m' => $id));
+        $viewurl = new moodle_url('/mod/moodleoverflow/view.php', ['m' => $id]);
 
         // Check whether a discussion is referenced.
         if ($discussionid) {

--- a/tests/dailymail_test.php
+++ b/tests/dailymail_test.php
@@ -72,7 +72,7 @@ class dailymail_test extends \advanced_testcase {
         $this->redirectMessages();
         // Create a new course with a moodleoverflow forum.
         $this->course = $this->getDataGenerator()->create_course();
-        $location = array('course' => $this->course->id, 'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE);
+        $location = ['course' => $this->course->id, 'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE];
         $this->moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $location);
         $this->coursemodule = get_coursemodule_from_instance('moodleoverflow', $this->moodleoverflow->id);
     }
@@ -94,7 +94,7 @@ class dailymail_test extends \advanced_testcase {
      */
     public function helper_create_user_and_discussion($maildigest) {
         // Create a user enrolled in the course as student.
-        $this->user = $this->getDataGenerator()->create_user(array('firstname' => 'Tamaro', 'maildigest' => $maildigest));
+        $this->user = $this->getDataGenerator()->create_user(['firstname' => 'Tamaro', 'maildigest' => $maildigest]);
         $this->getDataGenerator()->enrol_user($this->user->id, $this->course->id, 'student');
 
         // Create a new discussion and post within the moodleoverflow.
@@ -215,7 +215,7 @@ class dailymail_test extends \advanced_testcase {
         $this->helper_run_send_daily_mail();
 
         // Now check the database if the records of the users are deleted.
-        $records = $DB->get_records('moodleoverflow_mail_info', array('userid' => $this->user->id));
+        $records = $DB->get_records('moodleoverflow_mail_info', ['userid' => $this->user->id]);
         $this->assertEmpty($records);
     }
 }

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -165,7 +165,7 @@ class mod_moodleoverflow_generator extends testing_module_generator {
         $record->id = moodleoverflow_add_discussion($record, $modulecontext, $record->userid);
 
         if (isset($timemodified) || isset($mailed)) {
-            $post = $DB->get_record('moodleoverflow_posts', array('discussion' => $record->id));
+            $post = $DB->get_record('moodleoverflow_posts', ['discussion' => $record->id]);
 
             if (isset($mailed)) {
                 $post->mailed = $mailed;
@@ -180,7 +180,7 @@ class mod_moodleoverflow_generator extends testing_module_generator {
             $DB->update_record('moodleoverflow_discussions', $record);
         }
 
-        $discussion = $DB->get_record('moodleoverflow_discussions', array('id' => $record->id));
+        $discussion = $DB->get_record('moodleoverflow_discussions', ['id' => $record->id]);
 
         // Return the discussion object.
         return $discussion;
@@ -313,9 +313,9 @@ class mod_moodleoverflow_generator extends testing_module_generator {
         $record->moodleoverflow = $forum->id;
         $discussion = $this->create_discussion($record, $forum, $record);
         // Retrieve the post which was created by create_discussion.
-        $post = $DB->get_record('moodleoverflow_posts', array('discussion' => $discussion->id));
+        $post = $DB->get_record('moodleoverflow_posts', ['discussion' => $discussion->id]);
 
-        return array($discussion, $post);
+        return [$discussion, $post];
     }
 
     /**
@@ -327,7 +327,7 @@ class mod_moodleoverflow_generator extends testing_module_generator {
     public function update_post_time($post, $factor) {
         global $DB;
         // Update the post to have a created in the past.
-        $DB->set_field('moodleoverflow_posts', 'created', $post->created + $factor, array('id' => $post->id));
+        $DB->set_field('moodleoverflow_posts', 'created', $post->created + $factor, ['id' => $post->id]);
     }
 
     /**
@@ -339,9 +339,9 @@ class mod_moodleoverflow_generator extends testing_module_generator {
      */
     public function update_subscription_time($user, $discussion, $factor) {
         global $DB;
-        $sub = $DB->get_record('moodleoverflow_discuss_subs', array('userid' => $user->id, 'discussion' => $discussion->id));
+        $sub = $DB->get_record('moodleoverflow_discuss_subs', ['userid' => $user->id, 'discussion' => $discussion->id]);
         // Update the subscription to have a preference in the past.
-        $DB->set_field('moodleoverflow_discuss_subs', 'preference', $sub->preference + $factor, array('id' => $sub->id));
+        $DB->set_field('moodleoverflow_discuss_subs', 'preference', $sub->preference + $factor, ['id' => $sub->id]);
     }
 
     /**
@@ -379,7 +379,7 @@ class mod_moodleoverflow_generator extends testing_module_generator {
         $record = (object) [
             'discussion' => $parent->discussion,
             'parent' => $parent->id,
-            'userid' => $author->id
+            'userid' => $author->id,
         ];
         return $this->create_post($record, $straighttodb);
     }

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -57,7 +57,7 @@ class locallib_test extends advanced_testcase {
 
         $usercount = 5;
         $course = $this->getDataGenerator()->create_course();
-        $users = array();
+        $users = [];
 
         for ($i = 0; $i < $usercount; $i++) {
             $user = $this->getDataGenerator()->create_user();
@@ -65,11 +65,11 @@ class locallib_test extends advanced_testcase {
             $this->getDataGenerator()->enrol_user($user->id, $course->id);
         }
 
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE); // Automatic Subscription.
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE]; // Automatic Subscription.
         $mo = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Get the module context.
-        $cm = $DB->get_record('course_modules', array('id' => $mo->cmid));
+        $cm = $DB->get_record('course_modules', ['id' => $mo->cmid]);
         $context = \context_module::instance($cm->id);
 
         $result = \mod_moodleoverflow\subscriptions::get_subscribed_users($mo, $context);
@@ -90,7 +90,7 @@ class locallib_test extends advanced_testcase {
 
         $usercount = 5;
         $course = $this->getDataGenerator()->create_course();
-        $users = array();
+        $users = [];
 
         for ($i = 0; $i < $usercount; $i++) {
             $user = $this->getDataGenerator()->create_user();
@@ -98,10 +98,10 @@ class locallib_test extends advanced_testcase {
             $this->getDataGenerator()->enrol_user($user->id, $course->id);
         }
 
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE];
         $mo = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
-        $cm = $DB->get_record('course_modules', array('id' => $mo->cmid));
+        $cm = $DB->get_record('course_modules', ['id' => $mo->cmid]);
         $context = \context_module::instance($cm->id);
 
         $result = \mod_moodleoverflow\subscriptions::get_subscribed_users($mo, $context);
@@ -122,7 +122,7 @@ class locallib_test extends advanced_testcase {
 
         $usercount = 5;
         $course = $this->getDataGenerator()->create_course();
-        $users = array();
+        $users = [];
 
         for ($i = 0; $i < $usercount; $i++) {
             $user = $this->getDataGenerator()->create_user();
@@ -130,9 +130,9 @@ class locallib_test extends advanced_testcase {
             $this->getDataGenerator()->enrol_user($user->id, $course->id);
         }
 
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE); // Subscription optional.
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE]; // Subscription optional.
         $mo = $this->getDataGenerator()->create_module('moodleoverflow', $options);
-        $cm = $DB->get_record('course_modules', array('id' => $mo->cmid));
+        $cm = $DB->get_record('course_modules', ['id' => $mo->cmid]);
         $context = \context_module::instance($cm->id);
 
         $result = \mod_moodleoverflow\subscriptions::get_subscribed_users($mo, $context);
@@ -153,7 +153,7 @@ class locallib_test extends advanced_testcase {
 
         $usercount = 5;
         $course = $this->getDataGenerator()->create_course();
-        $users = array();
+        $users = [];
 
         for ($i = 0; $i < $usercount; $i++) {
             $user = $this->getDataGenerator()->create_user();
@@ -161,9 +161,9 @@ class locallib_test extends advanced_testcase {
             $this->getDataGenerator()->enrol_user($user->id, $course->id);
         }
 
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_DISALLOWSUBSCRIBE); // Subscription prevented.
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_DISALLOWSUBSCRIBE]; // Subscription prevented.
         $mo = $this->getDataGenerator()->create_module('moodleoverflow', $options);
-        $cm = $DB->get_record('course_modules', array('id' => $mo->cmid));
+        $cm = $DB->get_record('course_modules', ['id' => $mo->cmid]);
         $context = \context_module::instance($cm->id);
 
         $result = \mod_moodleoverflow\subscriptions::get_subscribed_users($mo, $context);

--- a/tests/post_test.php
+++ b/tests/post_test.php
@@ -79,14 +79,14 @@ class post_test extends \advanced_testcase {
         global $DB;
 
         // The attachment should exist.
-        $numberofattachments = count($DB->get_records('files', array('itemid' => $this->post->id)));
+        $numberofattachments = count($DB->get_records('files', ['itemid' => $this->post->id]));
         $this->assertEquals(2, $numberofattachments);
 
         // Delete the post from the teacher with its attachment.
         moodleoverflow_delete_post($this->post, false, $this->coursemodule, $this->moodleoverflow);
 
         // Now try to get the attachment.
-        $numberofattachments = count($DB->get_records('files', array('itemid' => $this->post->id)));
+        $numberofattachments = count($DB->get_records('files', ['itemid' => $this->post->id]));
 
         $this->assertEquals(0, $numberofattachments);
     }
@@ -98,14 +98,14 @@ class post_test extends \advanced_testcase {
     public function test_moodleoverflow_delete_discussion() {
         global $DB;
 
-        $numberofattachments = count($DB->get_records('files', array('itemid' => $this->post->id, 'filearea' => 'attachment')));
+        $numberofattachments = count($DB->get_records('files', ['itemid' => $this->post->id, 'filearea' => 'attachment']));
         $this->assertEquals(2, $numberofattachments);
 
         // Delete the post from the teacher with its attachment.
         moodleoverflow_delete_discussion($this->discussion[0], $this->course, $this->coursemodule, $this->moodleoverflow);
 
         // Now try to get the attachment.
-        $numberofattachments = count($DB->get_records('files', array('itemid' => $this->post->id)));
+        $numberofattachments = count($DB->get_records('files', ['itemid' => $this->post->id]));
         $this->assertEquals(0, $numberofattachments);
     }
 
@@ -118,18 +118,18 @@ class post_test extends \advanced_testcase {
         global $DB;
         // Create a new course with a moodleoverflow forum.
         $this->course = $this->getDataGenerator()->create_course();
-        $location = array('course' => $this->course->id);
+        $location = ['course' => $this->course->id];
         $this->moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $location);
         $this->coursemodule = get_coursemodule_from_instance('moodleoverflow', $this->moodleoverflow->id);
 
         // Create a teacher.
-        $this->teacher = $this->getDataGenerator()->create_user(array('firstname' => 'Tamaro', 'lastname' => 'Walter'));
+        $this->teacher = $this->getDataGenerator()->create_user(['firstname' => 'Tamaro', 'lastname' => 'Walter']);
         $this->getDataGenerator()->enrol_user($this->teacher->id, $this->course->id, 'student');
 
         // Create a discussion started from the teacher.
         $this->generator = $this->getDataGenerator()->get_plugin_generator('mod_moodleoverflow');
         $this->discussion = $this->generator->post_to_forum($this->moodleoverflow, $this->teacher);
-        $this->post = $DB->get_record('moodleoverflow_posts', array('id' => $this->discussion[0]->firstpost), '*');
+        $this->post = $DB->get_record('moodleoverflow_posts', ['id' => $this->discussion[0]->firstpost], '*');
 
         // Create an attachment by inserting it directly in the database and update the post record.
 

--- a/tests/privacy_provider_test.php
+++ b/tests/privacy_provider_test.php
@@ -27,8 +27,8 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 
 use core_privacy\local\request\approved_contextlist;
-use \core_privacy\local\request\userlist;
-use \mod_moodleoverflow\privacy\provider;
+use core_privacy\local\request\userlist;
+use mod_moodleoverflow\privacy\provider;
 use mod_moodleoverflow\privacy\data_export_helper;
 
 /**
@@ -307,7 +307,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
         $cm = get_coursemodule_from_instance('moodleoverflow', $forum->id);
         $context = \context_module::instance($cm->id);
         // Rate the other users content.
-        $rating = array();
+        $rating = [];
         $rating['moodleoverflowid'] = $forum->id;
         $rating['discussionid'] = $discussion->id;
         $rating['userid'] = $user->id;
@@ -351,7 +351,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
         $context = \context_module::instance($cm->id);
         // Other users rate my content.
         // Rate the other users content.
-        $rating = array();
+        $rating = [];
         $rating['moodleoverflowid'] = $forum->id;
         $rating['discussionid'] = $discussion->id;
         $rating['userid'] = $otheruser->id;
@@ -645,7 +645,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
             if ($post->userid != $user->id) {
                 $ratedposts[$post->id] = $post;
 
-                $rating = array();
+                $rating = [];
                 $rating['moodleoverflowid'] = $forum->id;
                 $rating['discussionid'] = $discussion->id;
                 $rating['userid'] = $user->id;
@@ -687,7 +687,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
         }
         // All ratings should have been deleted.
         foreach ($postsinforum as $post) {
-            $ratings = $DB->get_records('moodleoverflow_ratings', array('postid' => $post->id));
+            $ratings = $DB->get_records('moodleoverflow_ratings', ['postid' => $post->id]);
             $this->assertEmpty($ratings);
         }
 
@@ -716,7 +716,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
             if (!isset($ratedposts[$post->id])) {
                 continue;
             }
-            $ratings = $DB->get_records('moodleoverflow_ratings', array('postid' => $post->id));
+            $ratings = $DB->get_records('moodleoverflow_ratings', ['postid' => $post->id]);
             $this->assertNotEmpty($ratings);
         }
     }
@@ -797,7 +797,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
                 if ($post->userid != $user->id) {
                     $ratedposts[$post->id] = $post;
 
-                    $rating = array();
+                    $rating = [];
                     $rating['moodleoverflowid'] = $forum->id;
                     $rating['discussionid'] = $discussion->id;
                     $rating['userid'] = $user->id;
@@ -868,7 +868,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
         ));
 
         // Ratings should have been anonymized.
-        $this->assertCount(16, $DB->get_records('moodleoverflow_ratings', array('userid' => 0)));
+        $this->assertCount(16, $DB->get_records('moodleoverflow_ratings', ['userid' => 0]));
 
         // File count: (5 users * 2 forums * 1 file) = 10.
         // Files for the affected posts should be removed.
@@ -892,7 +892,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
             $forum = $this->getDataGenerator()->create_module('moodleoverflow', ['course' => $course->id]);
         }
 
-        return array($course, $forum);
+        return [$course, $forum];
     }
 
     /**
@@ -906,7 +906,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
      * @return array The users created
      */
     protected function create_users($course, $count) {
-        $users = array();
+        $users = [];
         for ($i = 0; $i < $count; $i++) {
             $user = $this->getDataGenerator()->create_user();
             $this->getDataGenerator()->enrol_user($user->id, $course->id);
@@ -925,7 +925,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
      * @return array The users created
      */
     protected function create_and_enrol_users($course, $count) {
-        $users = array();
+        $users = [];
         for ($i = 0; $i < $count; $i++) {
             $users[$i] = $this->getDataGenerator()->create_user();
             $this->getDataGenerator()->enrol_user($users[$i]->id, $course->id);
@@ -1039,7 +1039,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
                         'moodleoverflowid' => $moodleoverflow->id,
                         'rating' => 1,
                         'firstrated' => $time,
-                        'lastchanged' => $time
+                        'lastchanged' => $time,
                     ];
                     // Inserts a rating into the table.
                     $DB->insert_record('moodleoverflow_ratings', $rating);
@@ -1213,7 +1213,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
             'moodleoverflowid' => $moodleoverflow->id,
             'rating' => 1,
             'firstrated' => $time,
-            'lastchanged' => $time
+            'lastchanged' => $time,
         ];
         // Inserts a rating into the table.
         $DB->insert_record('moodleoverflow_ratings', $rating);
@@ -1429,7 +1429,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
                 'course' => $course->id,
                 'scale' => 100,
                 'grademaxgrade' => 50,
-                'gradescalefactor' => 2
+                'gradescalefactor' => 2,
         ]);
         $cm = get_coursemodule_from_instance('moodleoverflow', $forum->id);
         $context = \context_module::instance($cm->id);
@@ -1439,7 +1439,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
         \mod_moodleoverflow\ratings::moodleoverflow_add_rating($forum, $post->id, RATING_UPVOTE, $cm, $user2->id);
         moodleoverflow_update_all_grades_for_cm($forum->id);
         $grades = grade_get_grades($course->id, 'mod', 'moodleoverflow', $forum->id,
-                array($user->id, $user2->id));
+                [$user->id, $user2->id]);
         self::assertEquals("2.50", $grades->items[0]->grades[$user->id]->str_grade);
         self::assertEquals("0.50", $grades->items[0]->grades[$user2->id]->str_grade);
 
@@ -1456,7 +1456,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
         self::assertContains("$context->id", $contextlist->get_contextids());
         provider::delete_data_for_user($contextlist);
         moodleoverflow_update_all_grades_for_cm($forum->id);
-        $grades = $DB->get_records('moodleoverflow_grades', array('moodleoverflowid' => $forum->id), null,
+        $grades = $DB->get_records('moodleoverflow_grades', ['moodleoverflowid' => $forum->id], null,
                 'userid, grade');
         self::assertEquals(2.5, $grades[$user->id]->grade);
         self::assertArrayNotHasKey($user2->id, $grades);
@@ -1464,7 +1464,7 @@ class privacy_provider_test extends \core_privacy\tests\provider_testcase {
         // Test delete context.
         provider::delete_data_for_all_users_in_context($context);
         moodleoverflow_update_all_grades_for_cm($forum->id);
-        $grades = $DB->get_records('moodleoverflow_grades', array('moodleoverflowid' => $forum->id), null,
+        $grades = $DB->get_records('moodleoverflow_grades', ['moodleoverflowid' => $forum->id], null,
                 'userid, grade');
         self::assertEmpty($grades);
     }

--- a/tests/ratings_test.php
+++ b/tests/ratings_test.php
@@ -359,7 +359,7 @@ class ratings_test extends \advanced_testcase {
     private function set_ratingpreferences($preference) {
         if ($preference == 0 || $preference == 1) {
             $this->post->ratingpreference = $preference;
-            foreach([$this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6] as $answer) {
+            foreach ([$this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6] as $answer) {
                 $answer->ratingpreference = $preference;
             }
         }
@@ -512,11 +512,11 @@ class ratings_test extends \advanced_testcase {
      */
     private function create_twogroups($group1, $group2) {
         // Set the first 3 answers to the first group of rating.
-        foreach([$this->answer1, $this->answer2, $this->answer3] as $answer) {
+        foreach ([$this->answer1, $this->answer2, $this->answer3] as $answer) {
             $this->set_group($group1, $answer);
         }
         // Set the last 3 answers to the second group of rating.
-        foreach([$this->answer4, $this->answer5, $this->answer6] as $answer) {
+        foreach ([$this->answer4, $this->answer5, $this->answer6] as $answer) {
             $this->set_group($group2, $answer);
         }
 

--- a/tests/ratings_test.php
+++ b/tests/ratings_test.php
@@ -114,20 +114,16 @@ class ratings_test extends \advanced_testcase {
         // Test with every group of rating.
 
         // Create a array of the posts, save the sorted post and compare them to the order that they should have.
-        $posts = array($this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6);
+        $posts = [$this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6];
         $this->set_ratingpreferences(0);
-        $sortedposts = ratings::moodleoverflow_sort_answers_by_ratings($posts);
-        $rightorderposts = array($this->post, $this->answer1, $this->answer3, $this->answer2,
-                                 $this->answer4, $this->answer6, $this->answer5);
-        $result = $this->postsorderequal($sortedposts, $rightorderposts);
+        $rightorder = [$this->post, $this->answer1, $this->answer3, $this->answer2, $this->answer4, $this->answer6, $this->answer5];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
 
         // Change the rating preference of the teacher and sort again.
         $this->set_ratingpreferences(1);
-        $sortedposts = ratings::moodleoverflow_sort_answers_by_ratings($posts);
-        $rightorderposts = array($this->post, $this->answer1, $this->answer2, $this->answer3,
-                                 $this->answer4, $this->answer6, $this->answer5);
-        $result = $this->postsorderequal($sortedposts, $rightorderposts);
+        $rightorder = [$this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer6, $this->answer5];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
     }
 
@@ -141,45 +137,39 @@ class ratings_test extends \advanced_testcase {
         $this->create_everygroup();
 
         // Test without posts that are only marked as solved.
-        $posts = array($this->post, $this->answer1, $this->answer3, $this->answer4, $this->answer5, $this->answer6);
+        $posts = [$this->post, $this->answer1, $this->answer3, $this->answer4, $this->answer5, $this->answer6];
         $this->set_ratingpreferences(0);
-        $sortedposts = ratings::moodleoverflow_sort_answers_by_ratings($posts);
-        $rightorderposts = array($this->post, $this->answer1, $this->answer3, $this->answer4, $this->answer6, $this->answer5);
-        $result = $this->postsorderequal($sortedposts, $rightorderposts);
+        $rightorder = [$this->post, $this->answer1, $this->answer3, $this->answer4, $this->answer6, $this->answer5];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
 
         $this->set_ratingpreferences(1);
-        $sortedposts = ratings::moodleoverflow_sort_answers_by_ratings($posts);
-        $rightorderposts = array($this->post, $this->answer1, $this->answer3, $this->answer4, $this->answer6, $this->answer5);
-        $result = $this->postsorderequal($sortedposts, $rightorderposts);
+        $rightorder = [$this->post, $this->answer1, $this->answer3, $this->answer4, $this->answer6, $this->answer5];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
 
         // Test without posts that are only marked as helpful.
-        $posts = array($this->post, $this->answer1, $this->answer2, $this->answer4, $this->answer5, $this->answer6);
+        $posts = [$this->post, $this->answer1, $this->answer2, $this->answer4, $this->answer5, $this->answer6];
         $this->set_ratingpreferences(0);
-        $sortedposts = ratings::moodleoverflow_sort_answers_by_ratings($posts);
-        $rightorderposts = array($this->post, $this->answer1, $this->answer2, $this->answer4, $this->answer6, $this->answer5);
-        $result = $this->postsorderequal($sortedposts, $rightorderposts);
+        $rightorder = [$this->post, $this->answer1, $this->answer2, $this->answer4, $this->answer6, $this->answer5];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
 
         $this->set_ratingpreferences(1);
-        $sortedposts = ratings::moodleoverflow_sort_answers_by_ratings($posts);
-        $rightorderposts = array($this->post, $this->answer1, $this->answer2, $this->answer4, $this->answer6, $this->answer5);
-        $result = $this->postsorderequal($sortedposts, $rightorderposts);
+        $rightorder = [$this->post, $this->answer1, $this->answer2, $this->answer4, $this->answer6, $this->answer5];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
 
         // Test without posts that are marked as both helpful and solved.
-        $posts = array($this->post, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6);
+        $posts = [$this->post, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6];
         $this->set_ratingpreferences(0);
-        $sortedposts = ratings::moodleoverflow_sort_answers_by_ratings($posts);
-        $rightorderposts = array($this->post, $this->answer3, $this->answer2, $this->answer4, $this->answer6, $this->answer5);
-        $result = $this->postsorderequal($sortedposts, $rightorderposts);
+        $rightorder = [$this->post, $this->answer3, $this->answer2, $this->answer4, $this->answer6, $this->answer5];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
 
         $this->set_ratingpreferences(1);
-        $sortedposts = ratings::moodleoverflow_sort_answers_by_ratings($posts);
-        $rightorderposts = array($this->post, $this->answer2, $this->answer3, $this->answer4, $this->answer6, $this->answer5);
-        $result = $this->postsorderequal($sortedposts, $rightorderposts);
+        $rightorder = [$this->post, $this->answer2, $this->answer3, $this->answer4, $this->answer6, $this->answer5];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
     }
 
@@ -208,9 +198,8 @@ class ratings_test extends \advanced_testcase {
         $group1 = 's';
         $group2 = 'h';
         $this->set_ratingpreferences(0);
-        $rightorderposts = array($this->post, $this->answer6, $this->answer5, $this->answer4,
-            $this->answer2, $this->answer1, $this->answer3);
-        $this->process_groups($group1, $group2, $rightorderposts);
+        $rightorder = [$this->post, $this->answer6, $this->answer5, $this->answer4, $this->answer2, $this->answer1, $this->answer3];
+        $this->process_groups($group1, $group2, $rightorder);
 
         // Test case 5: only solved posts and only helpful posts with ratingpreferences = 1.
         $this->set_ratingpreferences(1);
@@ -219,11 +208,9 @@ class ratings_test extends \advanced_testcase {
         // Test case 6: only solved posts and not-marked posts.
         $group2 = 'o';
         $this->create_twogroups($group1, $group2);
-        $posts = array($this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6);
-        $sortedposts = ratings::moodleoverflow_sort_answers_by_ratings($posts);
-        $rightorderposts = array($this->post, $this->answer2, $this->answer1, $this->answer3,
-                                 $this->answer6, $this->answer5, $this->answer4);
-        $result = $this->postsorderequal($sortedposts, $rightorderposts);
+        $posts = [$this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6];
+        $rightorder = [$this->post, $this->answer2, $this->answer1, $this->answer3, $this->answer6, $this->answer5, $this->answer4];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
 
         // Test case 6: only helpful posts and not-marked posts.
@@ -238,6 +225,7 @@ class ratings_test extends \advanced_testcase {
      * - helpful, or
      * - solved, or
      * - not marked
+     * Extended Test Case: If the votesdifference is the same, the post should be sorted by their time of creation/modification.
      * @covers \ratings::moodleoverflow_sort_answer_by_ratings()
      */
     public function test_answersorting_onegroup() {
@@ -246,41 +234,54 @@ class ratings_test extends \advanced_testcase {
         // Test case 1: only solved and helpful posts.
         $group = 'sh';
         $this->create_onegroup($group);
-        $posts = array($this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6);
-        $sortedposts = ratings::moodleoverflow_sort_answers_by_ratings($posts);
-        $rightorderposts = array($this->post, $this->answer4, $this->answer6, $this->answer3,
-                                 $this->answer1, $this->answer2, $this->answer5);
-        $result = $this->postsorderequal($sortedposts, $rightorderposts);
+        $posts = [$this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6];
+        $rightorder = [$this->post, $this->answer4, $this->answer6, $this->answer3,$this->answer1, $this->answer2, $this->answer5];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
 
-        // Test case 1: only solvedposts.
+        // Now set the votesdifference equal for this group, sort again and check if they are sorted correctly after time.
+        $this->set_votesdifference();
+        $rightorder = [$this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
+        $this->assertEquals(1, $result);
+
+        // Test case 2: only solvedposts.
         $group = 's';
         $this->create_onegroup($group);
-        $posts = array($this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6);
-        $sortedposts = ratings::moodleoverflow_sort_answers_by_ratings($posts);
-        $rightorderposts = array($this->post, $this->answer4, $this->answer6, $this->answer3,
-                                 $this->answer1, $this->answer2, $this->answer5);
-        $result = $this->postsorderequal($sortedposts, $rightorderposts);
+        $rightorder = [$this->post, $this->answer4, $this->answer6, $this->answer3, $this->answer1, $this->answer2, $this->answer5];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
 
-        // Test case 1: only helpful posts.
+        // Now set the votesdifference equal for this group, sort again and check if they are sorted correctly after time.
+        $this->set_votesdifference();
+        $rightorder = [$this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
+        $this->assertEquals(1, $result);
+
+        // Test case 3: only helpful posts.
         $group = 'h';
         $this->create_onegroup($group);
-        $posts = array($this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6);
-        $sortedposts = ratings::moodleoverflow_sort_answers_by_ratings($posts);
-        $rightorderposts = array($this->post, $this->answer4, $this->answer6, $this->answer3,
-                                 $this->answer1, $this->answer2, $this->answer5);
-        $result = $this->postsorderequal($sortedposts, $rightorderposts);
+        $rightorder = [$this->post, $this->answer4, $this->answer6, $this->answer3, $this->answer1, $this->answer2, $this->answer5];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
 
-        // Test case 1: only not marked posts.
+        // Now set the votesdifference equal for this group, sort again and check if they are sorted correctly after time.
+        $this->set_votesdifference();
+        $rightorder = [$this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
+        $this->assertEquals(1, $result);
+
+        // Test case 4: only not marked posts.
         $group = 'o';
         $this->create_onegroup($group);
-        $posts = array($this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6);
-        $sortedposts = ratings::moodleoverflow_sort_answers_by_ratings($posts);
-        $rightorderposts = array($this->post, $this->answer4, $this->answer6, $this->answer3,
-                                 $this->answer1, $this->answer2, $this->answer5);
-        $result = $this->postsorderequal($sortedposts, $rightorderposts);
+        $rightorder = [$this->post, $this->answer4, $this->answer6, $this->answer3, $this->answer1, $this->answer2, $this->answer5];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
+        $this->assertEquals(1, $result);
+
+        // Now set the votesdifference equal for this group, sort again and check if they are sorted correctly after time.
+        $this->set_votesdifference();
+        $rightorder = [$this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6];
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
     }
 
@@ -296,24 +297,24 @@ class ratings_test extends \advanced_testcase {
         global $DB;
         // Create a new course with a moodleoverflow forum.
         $this->course = $this->getDataGenerator()->create_course();
-        $location = array('course' => $this->course->id);
+        $location = ['course' => $this->course->id];
         $this->moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $location);
         $this->coursemodule = get_coursemodule_from_instance('moodleoverflow', $this->moodleoverflow->id);
 
         // Create a teacher.
-        $this->teacher = $this->getDataGenerator()->create_user(array('firstname' => 'Tamaro', 'lastname' => 'Walter'));
+        $this->teacher = $this->getDataGenerator()->create_user(['firstname' => 'Tamaro', 'lastname' => 'Walter']);
         $this->getDataGenerator()->enrol_user($this->teacher->id, $this->course->id, 'student');
 
         // Create 2 users.
-        $this->user1 = $this->getDataGenerator()->create_user(array('firstname' => 'Ava', 'lastname' => 'Davis'));
+        $this->user1 = $this->getDataGenerator()->create_user(['firstname' => 'Ava', 'lastname' => 'Davis']);
         $this->getDataGenerator()->enrol_user($this->user1->id, $this->course->id, 'student');
-        $this->user2 = $this->getDataGenerator()->create_user(array('firstname' => 'Ethan', 'lastname' => 'Brown'));
+        $this->user2 = $this->getDataGenerator()->create_user(['firstname' => 'Ethan', 'lastname' => 'Brown']);
         $this->getDataGenerator()->enrol_user($this->user2->id, $this->course->id, 'student');
 
         // Create a discussion, a parent post and six answers.
         $this->generator = $this->getDataGenerator()->get_plugin_generator('mod_moodleoverflow');
         $this->discussion = $this->generator->post_to_forum($this->moodleoverflow, $this->teacher);
-        $this->post = $DB->get_record('moodleoverflow_posts', array('id' => $this->discussion[0]->firstpost), '*');
+        $this->post = $DB->get_record('moodleoverflow_posts', ['id' => $this->discussion[0]->firstpost], '*');
         $this->answer1 = $this->generator->reply_to_post($this->discussion[1], $this->user1, true);
         $this->answer2 = $this->generator->reply_to_post($this->discussion[1], $this->user1, true);
         $this->answer3 = $this->generator->reply_to_post($this->discussion[1], $this->user1, true);
@@ -326,22 +327,22 @@ class ratings_test extends \advanced_testcase {
     /**
      * This function compares 2 arrays with posts and checks if the order is the same.
      *
-     * @param array $sortedposts - The sorted posts
-     * @param array $rightorderposts       - The posts with the order they should have
+     * @param array $sortedposts      - The sorted posts
+     * @param array $rightorder       - The posts with the order they should have
      * The function returns 1 if $sortedposts matches $posts, else 0
      */
-    private function postsorderequal($sortedposts, $rightorderposts) {
-        if (count($sortedposts) != count($rightorderposts)) {
+    private function postsorderequal($sortedposts, $rightorder) {
+        if (count($sortedposts) != count($rightorder)) {
             return 0;
         }
         for ($i = 0; $i < count($sortedposts); $i++) {
             // Get the current elements.
             $sortedpost = current($sortedposts);
-            $post = current($rightorderposts);
+            $post = current($rightorder);
             if ($sortedpost->id == $post->id) {
                 // Go to the next elements.
                 next($sortedposts);
-                next($rightorderposts);
+                next($rightorder);
             } else {
                 return 0;
             }
@@ -350,7 +351,7 @@ class ratings_test extends \advanced_testcase {
     }
 
     /**
-     * sets the ratingpreferences to 1 or 0:
+     * Sets the ratingpreferences to 1 or 0:
      * 1 = solved posts will be shown above helpful posts.
      * 0 = helpful posts will be shown above solved posts.
      * @param int  $preference  the rating preference
@@ -365,6 +366,33 @@ class ratings_test extends \advanced_testcase {
             $this->answer5->ratingpreference = $preference;
             $this->answer6->ratingpreference = $preference;
         }
+    }
+
+    /**
+     * Sets the the votesdifference equal.
+     * The Right Order now (if the answers are in the same group) is:
+     * answer1, answer2, answer3, answer4, answer5, answer6.
+     * @return void
+     */
+    private function set_votesdifference() {
+        $this->answer1->upvotes = 3;
+        $this->answer1->downvotes = 3;
+        $this->answer1->votesdifference = $this->answer1->upvotes - $this->answer1->downvotes;
+        $this->answer2->upvotes = 4;
+        $this->answer2->downvotes = 4;
+        $this->answer2->votesdifference = $this->answer2->upvotes - $this->answer2->downvotes;
+        $this->answer3->upvotes = 1;
+        $this->answer3->downvotes = 1;
+        $this->answer3->votesdifference = $this->answer3->upvotes - $this->answer3->downvotes;
+        $this->answer4->upvotes = 2;
+        $this->answer4->downvotes = 2;
+        $this->answer4->votesdifference = $this->answer4->upvotes - $this->answer4->downvotes;
+        $this->answer5->upvotes = 5;
+        $this->answer5->downvotes = 5;
+        $this->answer5->votesdifference = $this->answer5->upvotes - $this->answer5->downvotes;
+        $this->answer6->upvotes = 6;
+        $this->answer6->downvotes = 6;
+        $this->answer6->votesdifference = $this->answer6->upvotes - $this->answer6->downvotes;
     }
 
     // Creation functions, that create different rating situations of the posts in a discussion.
@@ -431,7 +459,7 @@ class ratings_test extends \advanced_testcase {
      * - no mark (o)
      */
     private function create_onegroup($group) {
-        $answers = array($this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6);
+        $answers = [$this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6];
         foreach ($answers as $answer) {
             switch ($group) {
                 case 'sh':
@@ -621,14 +649,12 @@ class ratings_test extends \advanced_testcase {
      */
     private function process_groups(String $group1, string $group2, array $orderposts = null) {
         $this->create_twogroups($group1, $group2);
-        $posts = array($this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6);
-        $sortedposts = ratings::moodleoverflow_sort_answers_by_ratings($posts);
-        $rightorderposts = array($this->post, $this->answer2, $this->answer1, $this->answer3,
-            $this->answer6, $this->answer5, $this->answer4);
+        $posts = [$this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6];
+        $rightorder = [$this->post, $this->answer2, $this->answer1, $this->answer3, $this->answer6, $this->answer5, $this->answer4];
         if ($orderposts) {
-            $rightorderposts = $orderposts;
+            $rightorder = $orderposts;
         }
-        $result = $this->postsorderequal($sortedposts, $rightorderposts);
+        $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
     }
 }

--- a/tests/ratings_test.php
+++ b/tests/ratings_test.php
@@ -235,7 +235,7 @@ class ratings_test extends \advanced_testcase {
         $group = 'sh';
         $this->create_onegroup($group);
         $posts = [$this->post, $this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6];
-        $rightorder = [$this->post, $this->answer4, $this->answer6, $this->answer3,$this->answer1, $this->answer2, $this->answer5];
+        $rightorder = [$this->post, $this->answer4, $this->answer6, $this->answer3, $this->answer1, $this->answer2, $this->answer5];
         $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
 

--- a/tests/ratings_test.php
+++ b/tests/ratings_test.php
@@ -359,12 +359,9 @@ class ratings_test extends \advanced_testcase {
     private function set_ratingpreferences($preference) {
         if ($preference == 0 || $preference == 1) {
             $this->post->ratingpreference = $preference;
-            $this->answer1->ratingpreference = $preference;
-            $this->answer2->ratingpreference = $preference;
-            $this->answer3->ratingpreference = $preference;
-            $this->answer4->ratingpreference = $preference;
-            $this->answer5->ratingpreference = $preference;
-            $this->answer6->ratingpreference = $preference;
+            foreach([$this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6] as $answer) {
+                $answer->ratingpreference = $preference;
+            }
         }
     }
 
@@ -375,24 +372,11 @@ class ratings_test extends \advanced_testcase {
      * @return void
      */
     private function set_votesdifference() {
-        $this->answer1->upvotes = 3;
-        $this->answer1->downvotes = 3;
-        $this->answer1->votesdifference = $this->answer1->upvotes - $this->answer1->downvotes;
-        $this->answer2->upvotes = 4;
-        $this->answer2->downvotes = 4;
-        $this->answer2->votesdifference = $this->answer2->upvotes - $this->answer2->downvotes;
-        $this->answer3->upvotes = 1;
-        $this->answer3->downvotes = 1;
-        $this->answer3->votesdifference = $this->answer3->upvotes - $this->answer3->downvotes;
-        $this->answer4->upvotes = 2;
-        $this->answer4->downvotes = 2;
-        $this->answer4->votesdifference = $this->answer4->upvotes - $this->answer4->downvotes;
-        $this->answer5->upvotes = 5;
-        $this->answer5->downvotes = 5;
-        $this->answer5->votesdifference = $this->answer5->upvotes - $this->answer5->downvotes;
-        $this->answer6->upvotes = 6;
-        $this->answer6->downvotes = 6;
-        $this->answer6->votesdifference = $this->answer6->upvotes - $this->answer6->downvotes;
+        foreach ([$this->answer1, $this->answer2, $this->answer3, $this->answer4, $this->answer5, $this->answer6] as $answer) {
+            $answer->upvotes = 1;
+            $answer->downvotes = 1;
+            $answer->votesdifference = $answer->upvotes - $answer->downvotes;;
+        }
     }
 
     // Creation functions, that create different rating situations of the posts in a discussion.
@@ -528,106 +512,21 @@ class ratings_test extends \advanced_testcase {
      */
     private function create_twogroups($group1, $group2) {
         // Set the first 3 answers to the first group of rating.
-        switch ($group1) {
-            case 'sh':
-                $this->answer1->markedhelpful = 1;
-                $this->answer1->markedsolution = 1;
-                $this->answer2->markedhelpful = 1;
-                $this->answer2->markedsolution = 1;
-                $this->answer3->markedhelpful = 1;
-                $this->answer3->markedsolution = 1;
-                break;
-            case 's':
-                $this->answer1->markedhelpful = 0;
-                $this->answer1->markedsolution = 1;
-                $this->answer2->markedhelpful = 0;
-                $this->answer2->markedsolution = 1;
-                $this->answer3->markedhelpful = 0;
-                $this->answer3->markedsolution = 1;
-                break;
-            case 'h':
-                $this->answer1->markedhelpful = 1;
-                $this->answer1->markedsolution = 0;
-                $this->answer2->markedhelpful = 1;
-                $this->answer2->markedsolution = 0;
-                $this->answer3->markedhelpful = 1;
-                $this->answer3->markedsolution = 0;
-                break;
-            case 'o':
-                $this->answer1->markedhelpful = 0;
-                $this->answer1->markedsolution = 0;
-                $this->answer2->markedhelpful = 0;
-                $this->answer2->markedsolution = 0;
-                $this->answer3->markedhelpful = 0;
-                $this->answer3->markedsolution = 0;
-                break;
+        foreach([$this->answer1, $this->answer2, $this->answer3] as $answer) {
+            $this->set_group($group1, $answer);
         }
-
-        switch ($group2) {
-            case 'sh':
-                $this->answer4->markedhelpful = 1;
-                $this->answer4->markedsolution = 1;
-                $this->answer5->markedhelpful = 1;
-                $this->answer5->markedsolution = 1;
-                $this->answer6->markedhelpful = 1;
-                $this->answer6->markedsolution = 1;
-                break;
-            case 's':
-                $this->answer4->markedhelpful = 0;
-                $this->answer4->markedsolution = 1;
-                $this->answer5->markedhelpful = 0;
-                $this->answer5->markedsolution = 1;
-                $this->answer6->markedhelpful = 0;
-                $this->answer6->markedsolution = 1;
-                break;
-            case 'h':
-                $this->answer4->markedhelpful = 1;
-                $this->answer4->markedsolution = 0;
-                $this->answer5->markedhelpful = 1;
-                $this->answer5->markedsolution = 0;
-                $this->answer6->markedhelpful = 1;
-                $this->answer6->markedsolution = 0;
-                break;
-            case 'o':
-                $this->answer4->markedhelpful = 0;
-                $this->answer4->markedsolution = 0;
-                $this->answer5->markedhelpful = 0;
-                $this->answer5->markedsolution = 0;
-                $this->answer6->markedhelpful = 0;
-                $this->answer6->markedsolution = 0;
-                break;
+        // Set the last 3 answers to the second group of rating.
+        foreach([$this->answer4, $this->answer5, $this->answer6] as $answer) {
+            $this->set_group($group2, $answer);
         }
 
         // Now set the up and downvotes for every answer.
-        // Answer1.
-        $this->answer1->upvotes = 3;
-        $this->answer1->downvotes = 4;
-        $this->answer1->votesdifference = $this->answer1->upvotes - $this->answer1->downvotes; // Vd = -1.
-
-        // Answer2.
-        $this->answer2->upvotes = 4;
-        $this->answer2->downvotes = 1;
-        $this->answer2->votesdifference = $this->answer2->upvotes - $this->answer2->downvotes; // Vd = 3.
-
-        // Answer3.
-        $this->answer3->upvotes = 0;
-        $this->answer3->downvotes = 2;
-        $this->answer3->votesdifference = $this->answer3->upvotes - $this->answer3->downvotes; // Vd = -2.
-
-        // Answer4.
-        $this->answer4->upvotes = 5;
-        $this->answer4->downvotes = 5;
-        $this->answer4->votesdifference = $this->answer4->upvotes - $this->answer4->downvotes; // Vd = 0.
-
-        // Answer5.
-        $this->answer5->upvotes = 6;
-        $this->answer5->downvotes = 5;
-        $this->answer5->votesdifference = $this->answer5->upvotes - $this->answer5->downvotes; // Vd = 1.
-
-        // Answer6.
-        $this->answer6->upvotes = 4;
-        $this->answer6->downvotes = 2;
-        $this->answer6->votesdifference = $this->answer6->upvotes - $this->answer6->downvotes; // Vd = 2.
+        $this->set_votes($this->answer1, 3, 4); // Votesdifference = -1.
+        $this->set_votes($this->answer2, 4, 1); // Votesdifference = -3.
+        $this->set_votes($this->answer3, 0, 2); // Votesdifference = -2.
+        $this->set_votes($this->answer4, 5, 5); // Votesdifference = 0.
+        $this->set_votes($this->answer5, 6, 5); // Votesdifference = 1.
+        $this->set_votes($this->answer6, 4, 2); // Votesdifference = 2.
 
         // The Rightorder depends now on the group parameter.
         // Rightorder (sh,s) = answer2, answer1, answer3, answer6, answer5, answer4.
@@ -637,7 +536,6 @@ class ratings_test extends \advanced_testcase {
         // Rightorder (s,h) = answer2, answer1, answer3, answer6, answer5, answer4. with ratingpreference = 1
         // Rightorder (s,o) = answer2, answer1, answer3, answer6, answer5, answer4.
         // Rightorder (h,o) = answer2, answer1, answer3, answer6, answer5, answer4.
-
     }
 
     /**
@@ -656,5 +554,45 @@ class ratings_test extends \advanced_testcase {
         }
         $result = $this->postsorderequal(ratings::moodleoverflow_sort_answers_by_ratings($posts), $rightorder);
         $this->assertEquals(1, $result);
+    }
+
+    /**
+     * Sets a post to a group of mark.
+     * @param String $group Group can be: solved+helpful, solved, helpful, not marked
+     * @param $answer
+     * @return void
+     */
+    private function set_group(String $group, $answer) {
+        switch($group) {
+            case 'sh':
+                $answer->markedhelpful = 1;
+                $answer->markedsolution = 1;
+                break;
+            case 's':
+                $answer->markedhelpful = 0;
+                $answer->markedsolution = 1;
+                break;
+            case 'h':
+                $answer->markedhelpful = 1;
+                $answer->markedsolution = 0;
+                break;
+            case 'o':
+                $answer->markedhelpful = 0;
+                $answer->markedsolution = 0;
+                break;
+        }
+    }
+
+    /**
+     * Sets the votes and votesdifference of a post.
+     * @param mixed $answer     The post
+     * @param int $upvotes
+     * @param int $downvotes
+     * @return void
+     */
+    private function set_votes($answer, $upvotes, $downvotes) {
+        $answer->upvotes = $upvotes;
+        $answer->downvotes = $downvotes;
+        $answer->votesdifference = $answer->upvotes - $answer->downvotes;
     }
 }

--- a/tests/readtracking_test.php
+++ b/tests/readtracking_test.php
@@ -49,13 +49,13 @@ class readtracking_test extends advanced_testcase {
         $this->resetAfterTest();
 
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id, 'trackingtype' => MOODLEOVERFLOW_TRACKING_OFF); // Off.
+        $options = ['course' => $course->id, 'trackingtype' => MOODLEOVERFLOW_TRACKING_OFF]; // Off.
         $mooff = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
-        $options = array('course' => $course->id, 'trackingtype' => MOODLEOVERFLOW_TRACKING_FORCED); // On.
+        $options = ['course' => $course->id, 'trackingtype' => MOODLEOVERFLOW_TRACKING_FORCED]; // On.
         $moforce = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
-        $options = array('course' => $course->id, 'trackingtype' => MOODLEOVERFLOW_TRACKING_OPTIONAL); // Optional.
+        $options = ['course' => $course->id, 'trackingtype' => MOODLEOVERFLOW_TRACKING_OPTIONAL]; // Optional.
         $mooptional = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Allow force.
@@ -98,13 +98,13 @@ class readtracking_test extends advanced_testcase {
 
         $course = $this->getDataGenerator()->create_course();
 
-        $options = array('course' => $course->id, 'trackingtype' => MOODLEOVERFLOW_TRACKING_OPTIONAL);
+        $options = ['course' => $course->id, 'trackingtype' => MOODLEOVERFLOW_TRACKING_OPTIONAL];
         $mooptional = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
-        $options = array('course' => $course->id, 'trackingtype' => MOODLEOVERFLOW_TRACKING_FORCED);
+        $options = ['course' => $course->id, 'trackingtype' => MOODLEOVERFLOW_TRACKING_FORCED];
         $moforce = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
-        $options = array('course' => $course->id, 'trackingtype' => MOODLEOVERFLOW_TRACKING_OFF);
+        $options = ['course' => $course->id, 'trackingtype' => MOODLEOVERFLOW_TRACKING_OFF];
         $mooff = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Allow force.

--- a/tests/review_test.php
+++ b/tests/review_test.php
@@ -112,8 +112,8 @@ class review_test extends \advanced_testcase {
         global $DB, $CFG;
         require_once($CFG->dirroot . '/mod/moodleoverflow/externallib.php');
 
-        $options = array('course' => $this->course->id, 'needsreview' => review::EVERYTHING,
-            'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE);
+        $options = ['course' => $this->course->id, 'needsreview' => review::EVERYTHING,
+            'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE];
 
         $posts = $this->create_post($options);
         $this->check_mail_records($posts['teacherpost'], $posts['studentpost'], 1, 0, MOODLEOVERFLOW_MAILED_REVIEW_SUCCESS);
@@ -177,8 +177,8 @@ class review_test extends \advanced_testcase {
         global $DB, $CFG;
         require_once($CFG->dirroot . '/mod/moodleoverflow/externallib.php');
 
-        $options = array('course' => $this->course->id, 'needsreview' => review::QUESTIONS,
-            'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE);
+        $options = ['course' => $this->course->id, 'needsreview' => review::QUESTIONS,
+            'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE];
         $posts = $this->create_post($options);
         $this->check_mail_records($posts['teacherpost'], $posts['studentpost'], 1, 0, MOODLEOVERFLOW_MAILED_REVIEW_SUCCESS);
 
@@ -215,8 +215,8 @@ class review_test extends \advanced_testcase {
      * Test reviews functionality when reviewing is allowed in admin settings.
      */
     public function test_forum_review_disallowed() {
-        $options = array('course' => $this->course->id, 'needsreview' => review::EVERYTHING,
-            'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE);
+        $options = ['course' => $this->course->id, 'needsreview' => review::EVERYTHING,
+            'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE];
 
         set_config('allowreview', 0, 'moodleoverflow');
 
@@ -276,7 +276,7 @@ class review_test extends \advanced_testcase {
         list(, $teacherpost) = $this->generator->post_to_forum($moodleoverflow, $this->teacher);
         list(, $studentpost) = $this->generator->post_to_forum($moodleoverflow, $this->student);
 
-        return array('teacherpost' => $teacherpost, 'studentpost' => $studentpost);
+        return ['teacherpost' => $teacherpost, 'studentpost' => $studentpost];
     }
 
     /**

--- a/tests/subscriptions_test.php
+++ b/tests/subscriptions_test.php
@@ -68,7 +68,7 @@ class subscriptions_test extends advanced_testcase {
      * @return array The users created
      */
     protected function helper_create_users($course, $count) {
-        $users = array();
+        $users = [];
 
         for ($i = 0; $i < $count; $i++) {
             $user = $this->getDataGenerator()->create_user();
@@ -101,10 +101,10 @@ class subscriptions_test extends advanced_testcase {
         $discussion = $generator->create_discussion($record, $moodleoverflow);
 
         // Retrieve the post which was created.
-        $post = $DB->get_record('moodleoverflow_posts', array('discussion' => $discussion->id));
+        $post = $DB->get_record('moodleoverflow_posts', ['discussion' => $discussion->id]);
 
         // Return the discussion and the post.
-        return array($discussion->id, $post);
+        return [$discussion->id, $post];
     }
 
     /**
@@ -118,7 +118,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course with a moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id);
+        $options = ['course' => $course->id];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
         $modulecontext = \context_module::instance($moodleoverflow->cmid);
 
@@ -130,7 +130,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Test the forced subscription.
         \mod_moodleoverflow\subscriptions::set_subscription_mode($moodleoverflow->id, MOODLEOVERFLOW_FORCESUBSCRIBE);
-        $moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $moodleoverflow->id));
+        $moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflow->id]);
         $this->assertEquals(MOODLEOVERFLOW_FORCESUBSCRIBE,
             \mod_moodleoverflow\subscriptions::get_subscription_mode($moodleoverflow));
         $this->assertTrue(\mod_moodleoverflow\subscriptions::is_forcesubscribed($moodleoverflow));
@@ -139,21 +139,21 @@ class subscriptions_test extends advanced_testcase {
 
         // Test the disallowed subscription.
         \mod_moodleoverflow\subscriptions::set_subscription_mode($moodleoverflow->id, MOODLEOVERFLOW_DISALLOWSUBSCRIBE);
-        $moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $moodleoverflow->id));
+        $moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflow->id]);
         $this->assertTrue(\mod_moodleoverflow\subscriptions::subscription_disabled($moodleoverflow));
         $this->assertFalse(\mod_moodleoverflow\subscriptions::is_subscribable($moodleoverflow, $modulecontext));
         $this->assertFalse(\mod_moodleoverflow\subscriptions::is_forcesubscribed($moodleoverflow));
 
         // Test the initial subscription.
         \mod_moodleoverflow\subscriptions::set_subscription_mode($moodleoverflow->id, MOODLEOVERFLOW_INITIALSUBSCRIBE);
-        $moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $moodleoverflow->id));
+        $moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflow->id]);
         $this->assertTrue(\mod_moodleoverflow\subscriptions::is_subscribable($moodleoverflow, $modulecontext));
         $this->assertFalse(\mod_moodleoverflow\subscriptions::subscription_disabled($moodleoverflow));
         $this->assertFalse(\mod_moodleoverflow\subscriptions::is_forcesubscribed($moodleoverflow));
 
         // Test the choose subscription.
         \mod_moodleoverflow\subscriptions::set_subscription_mode($moodleoverflow->id, MOODLEOVERFLOW_CHOOSESUBSCRIBE);
-        $moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $moodleoverflow->id));
+        $moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $moodleoverflow->id]);
         $this->assertTrue(\mod_moodleoverflow\subscriptions::is_subscribable($moodleoverflow, $modulecontext));
         $this->assertFalse(\mod_moodleoverflow\subscriptions::subscription_disabled($moodleoverflow));
         $this->assertFalse(\mod_moodleoverflow\subscriptions::is_forcesubscribed($moodleoverflow));
@@ -168,7 +168,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course with a moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id);
+        $options = ['course' => $course->id];
         $mof = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Get the module context.
@@ -186,13 +186,13 @@ class subscriptions_test extends advanced_testcase {
         $this->assertEquals(0, count($result));
 
         // Create the moodleoverflows.
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE];
         $this->getDataGenerator()->create_module('moodleoverflow', $options);
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_DISALLOWSUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_DISALLOWSUBSCRIBE];
         $disallow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE];
         $choose = $this->getDataGenerator()->create_module('moodleoverflow', $options);
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE];
         $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // At present the user is only subscribed to the initial moodleoverflow.
@@ -219,7 +219,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course with a moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id);
+        $options = ['course' => $course->id];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Get the module context.
@@ -244,139 +244,139 @@ class subscriptions_test extends advanced_testcase {
             $modulecontext, $discussion->id));
 
         // Check thast we have no records in either on the subscription tables.
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(0, $count);
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(0, $count);
 
         // Subscribing to the moodleoverflow should create a record in the subscription table,
         // but the moodleoverflow discussion subscriptions table.
         \mod_moodleoverflow\subscriptions::subscribe_user($author->id, $moodleoverflow, $modulecontext);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(1, $count);
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(0, $count);
 
         // Unsubscribing should remove the record from the moodleoverflow subscription table.
         // Do not modify the moodleoverflow discussion subscriptions table.
         \mod_moodleoverflow\subscriptions::unsubscribe_user($author->id, $moodleoverflow, $modulecontext);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(0, $count);
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(0, $count);
 
         // Enroling the user in the discussion should add one record to the
         // moodleoverflow discussion table without modifying the form subscription.
         \mod_moodleoverflow\subscriptions::subscribe_user_to_discussion($author->id, $discussion, $modulecontext);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(0, $count);
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(1, $count);
 
         // Unsubscribing should remove the record from the moodleoverflow subscriptions
         // table and not modify the moodleoverflow discussion subscription table.
         \mod_moodleoverflow\subscriptions::unsubscribe_user_from_discussion($author->id, $discussion, $modulecontext);
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(0, $count);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(0, $count);
 
         // Resubscribe to the discussion so that we can check the effect of moodleoverflow-level subscriptions.
         \mod_moodleoverflow\subscriptions::subscribe_user_to_discussion($author->id, $discussion, $modulecontext);
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(1, $count);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(0, $count);
 
         // Subscribing to the moodleoverflow should have no effect on the moodleoverflow discussion
         // subscription table if the user did not request the change himself.
         \mod_moodleoverflow\subscriptions::subscribe_user($author->id, $moodleoverflow, $modulecontext);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(1, $count);
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(1, $count);
 
         // Unsubbing from the moodleoverflow should have no effect on the moodleoverflow
         // discussion subscription table if the user did not request the change themself.
         \mod_moodleoverflow\subscriptions::unsubscribe_user($author->id, $moodleoverflow, $modulecontext);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(0, $count);
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(1, $count);
 
         // Subscribing to the moodleoverflow should remove the per-discussion
         // subscription preference if the user requested the change themself.
         \mod_moodleoverflow\subscriptions::subscribe_user($author->id, $moodleoverflow, $modulecontext, true);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(1, $count);
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(0, $count);
 
         // Now unsubscribe from the current discussion whilst being subscribed to the moodleoverflow as a whole.
         \mod_moodleoverflow\subscriptions::unsubscribe_user_from_discussion($author->id, $discussion, $modulecontext);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(1, $count);
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(1, $count);
 
         // Unsubscribing from the moodleoverflow should remove the per-discussion
         // subscription preference if the user requested the change himself.
         \mod_moodleoverflow\subscriptions::unsubscribe_user($author->id, $moodleoverflow, $modulecontext, true);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(0, $count);
-        $count = $DB->count_records('moodleoverflow_discuss_subs', array(
+        $count = $DB->count_records('moodleoverflow_discuss_subs', [
             'userid' => $author->id,
             'discussion' => $discussion->id,
-        ));
+        ]);
         $this->assertEquals(0, $count);
 
         // Subscribe to the discussion.
         \mod_moodleoverflow\subscriptions::subscribe_user_to_discussion($author->id, $discussion, $modulecontext);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(0, $count);
-        $count = $DB->count_records('moodleoverflow_discuss_subs', array(
+        $count = $DB->count_records('moodleoverflow_discuss_subs', [
             'userid' => $author->id,
             'discussion' => $discussion->id,
-        ));
+        ]);
         $this->assertEquals(1, $count);
 
         // Subscribe to the moodleoverflow without removing the discussion preferences.
         \mod_moodleoverflow\subscriptions::subscribe_user($author->id, $moodleoverflow, $modulecontext);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(1, $count);
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(1, $count);
 
         // Unsubscribe from the discussion should result in a change.
         \mod_moodleoverflow\subscriptions::unsubscribe_user_from_discussion($author->id, $discussion, $modulecontext);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(1, $count);
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(1, $count);
     }
@@ -390,7 +390,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course with a moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Create users enrolled in the course as students.
@@ -417,7 +417,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course with a moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Get the module context.
@@ -456,7 +456,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course and a new moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Get the module context.
@@ -500,7 +500,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course, with a moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Get the module context.
@@ -544,7 +544,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course with a moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         $cm = get_coursemodule_from_instance('moodleoverflow', $moodleoverflow->id);
@@ -574,10 +574,10 @@ class subscriptions_test extends advanced_testcase {
             $discussion, $modulecontext));
 
         // And there should be no discussion subscriptions (and one moodleoverflow subscription).
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(0, $count);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(1, $count);
 
@@ -592,10 +592,10 @@ class subscriptions_test extends advanced_testcase {
             $discussion, $modulecontext));
 
         // And there should be a discussion subscriptions (and one moodleoverflow subscription).
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(1, $count);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(1, $count);
 
@@ -604,12 +604,12 @@ class subscriptions_test extends advanced_testcase {
             $discussion->id));
 
         // There should be a record in the discussion subscription tracking table.
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(1, $count);
 
         // And one in the moodleoverflow subscription tracking table.
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(1, $count);
 
@@ -624,12 +624,12 @@ class subscriptions_test extends advanced_testcase {
             $discussion->id));
 
         // And one in the moodleoverflow subscription tracking table.
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(1, $count);
 
         // There should be no record in the discussion subscription tracking table.
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(0, $count);
 
@@ -644,12 +644,12 @@ class subscriptions_test extends advanced_testcase {
             $discussion->id));
 
         // And one in the moodleoverflow subscription tracking table.
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(1, $count);
 
         // There should be a record in the discussion subscription tracking table.
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(1, $count);
 
@@ -665,12 +665,12 @@ class subscriptions_test extends advanced_testcase {
             $discussion->id));
 
         // There should be no record in the discussion subscription tracking table.
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(0, $count);
 
         // And one in the forum subscription tracking table.
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(1, $count);
 
@@ -685,12 +685,12 @@ class subscriptions_test extends advanced_testcase {
         $this->assertTrue(\mod_moodleoverflow\subscriptions::is_subscribed($author->id, $moodleoverflow, $modulecontext));
 
         // There should be a record in the discussion subscription tracking table.
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(1, $count);
 
         // And one in the moodleoverflow subscription tracking table.
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(1, $count);
 
@@ -699,10 +699,10 @@ class subscriptions_test extends advanced_testcase {
             true));
 
         // This removes both the moodleoverflow, and the moodleoverflow records.
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(0, $count);
-        $options = array('userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id);
+        $options = ['userid' => $author->id, 'moodleoverflow' => $moodleoverflow->id];
         $count = $DB->count_records('moodleoverflow_subscriptions', $options);
         $this->assertEquals(0, $count);
 
@@ -723,7 +723,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course, with a moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Get the module context.
@@ -762,7 +762,7 @@ class subscriptions_test extends advanced_testcase {
             $discussion->id));
 
         // There should be a record in the discussion subscription tracking table.
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(1, $count);
 
@@ -777,7 +777,7 @@ class subscriptions_test extends advanced_testcase {
             $discussion->id));
 
         // There should be no record in the discussion subscription tracking table.
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(0, $count);
 
@@ -792,7 +792,7 @@ class subscriptions_test extends advanced_testcase {
         $this->assertFalse(\mod_moodleoverflow\subscriptions::is_subscribed($author->id, $moodleoverflow, $modulecontext));
 
         // There should be a record in the discussion subscription tracking table.
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(1, $count);
 
@@ -807,7 +807,7 @@ class subscriptions_test extends advanced_testcase {
         $this->assertFalse(\mod_moodleoverflow\subscriptions::is_subscribed($author->id, $moodleoverflow, $modulecontext));
 
         // There should be no record in the discussion subscription tracking table.
-        $options = array('userid' => $author->id, 'discussion' => $discussion->id);
+        $options = ['userid' => $author->id, 'discussion' => $discussion->id];
         $count = $DB->count_records('moodleoverflow_discuss_subs', $options);
         $this->assertEquals(0, $count);
     }
@@ -824,7 +824,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course, with a moodleoverflow. where users are initially subscribed.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Get the module context.
@@ -865,7 +865,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course, with a moodleoverflow. where users are initially subscribed.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Get the module context.
@@ -892,7 +892,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course, with a moodleoverflow. where users are initially subscribed.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Get the module context.
@@ -979,7 +979,7 @@ class subscriptions_test extends advanced_testcase {
         // Create a course, with a moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
 
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_FORCESUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Remove the allowforcesubscribe capability from the user.
@@ -1011,7 +1011,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course, with a moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Create some users.
@@ -1046,7 +1046,7 @@ class subscriptions_test extends advanced_testcase {
         // Create a course, with a moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
 
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Create some users.
@@ -1079,11 +1079,11 @@ class subscriptions_test extends advanced_testcase {
         $course = $this->getDataGenerator()->create_course();
 
         // Create the moodleoverflows.
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_DISALLOWSUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_DISALLOWSUBSCRIBE];
         $disallowmoodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE];
         $choosemoodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE];
         $initialmoodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Create some users and keep a reference to the first user.
@@ -1130,7 +1130,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course, with a moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Get the module context.
@@ -1141,7 +1141,7 @@ class subscriptions_test extends advanced_testcase {
         $users = $this->helper_create_users($course, 20);
 
         // Post some discussions to the moodleoverflow.
-        $discussions = array();
+        $discussions = [];
         $author = $users[0];
         for ($i = 0; $i < 20; $i++) {
             $discussion = new \stdClass();
@@ -1197,14 +1197,14 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course, with a moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_INITIALSUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Create some users.
         $users = $this->helper_create_users($course, 20);
 
         // Post some discussions to the moodleoverflow.
-        $discussions = array();
+        $discussions = [];
         $author = $users[0];
         for ($i = 0; $i < 20; $i++) {
             $discussion = new \stdClass();
@@ -1270,7 +1270,7 @@ class subscriptions_test extends advanced_testcase {
 
         // Create a course, with a moodleoverflow.
         $course = $this->getDataGenerator()->create_course();
-        $options = array('course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE);
+        $options = ['course' => $course->id, 'forcesubscribe' => MOODLEOVERFLOW_CHOOSESUBSCRIBE];
         $moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $options);
 
         // Get the module context.
@@ -1294,26 +1294,26 @@ class subscriptions_test extends advanced_testcase {
             $discussion->id));
 
         // Confirm that we have no records in either of the subscription tables.
-        $this->assertEquals(0, $DB->count_records('moodleoverflow_subscriptions', array(
+        $this->assertEquals(0, $DB->count_records('moodleoverflow_subscriptions', [
             'userid' => $user->id,
             'moodleoverflow' => $moodleoverflow->id,
-        )));
-        $this->assertEquals(0, $DB->count_records('moodleoverflow_discuss_subs', array(
+        ]));
+        $this->assertEquals(0, $DB->count_records('moodleoverflow_discuss_subs', [
             'userid' => $user->id,
             'discussion' => $discussion->id,
-        )));
+        ]));
 
         // Subscribing to the moodleoverflow should create a record in the subscriptions table,
         // but not the moodleoverflow discussion subscriptions table.
         \mod_moodleoverflow\subscriptions::subscribe_user($user->id, $moodleoverflow, $modulecontext);
-        $this->assertEquals(1, $DB->count_records('moodleoverflow_subscriptions', array(
+        $this->assertEquals(1, $DB->count_records('moodleoverflow_subscriptions', [
             'userid' => $user->id,
             'moodleoverflow' => $moodleoverflow->id,
-        )));
-        $this->assertEquals(0, $DB->count_records('moodleoverflow_discuss_subs', array(
+        ]));
+        $this->assertEquals(0, $DB->count_records('moodleoverflow_discuss_subs', [
             'userid' => $user->id,
             'discussion' => $discussion->id,
-        )));
+        ]));
 
         // Now unsubscribe from the discussion. This should return true.
         $uid = $user->id;
@@ -1334,25 +1334,25 @@ class subscriptions_test extends advanced_testcase {
         // And unsubscribing from the moodleoverflow but not as a request from the user should maintain their preference.
         \mod_moodleoverflow\subscriptions::unsubscribe_user($user->id, $moodleoverflow, $modulecontext);
 
-        $this->assertEquals(0, $DB->count_records('moodleoverflow_subscriptions', array(
+        $this->assertEquals(0, $DB->count_records('moodleoverflow_subscriptions', [
             'userid' => $user->id,
             'moodleoverflow' => $moodleoverflow->id,
-        )));
-        $this->assertEquals(1, $DB->count_records('moodleoverflow_discuss_subs', array(
+        ]));
+        $this->assertEquals(1, $DB->count_records('moodleoverflow_discuss_subs', [
             'userid' => $user->id,
             'discussion' => $discussion->id,
-        )));
+        ]));
 
         // Subscribing to the discussion should return truthfully because a change was made.
         $this->assertTrue(\mod_moodleoverflow\subscriptions::subscribe_user_to_discussion($user->id, $discussion, $modulecontext));
-        $this->assertEquals(0, $DB->count_records('moodleoverflow_subscriptions', array(
+        $this->assertEquals(0, $DB->count_records('moodleoverflow_subscriptions', [
             'userid' => $user->id,
             'moodleoverflow' => $moodleoverflow->id,
-        )));
-        $this->assertEquals(1, $DB->count_records('moodleoverflow_discuss_subs', array(
+        ]));
+        $this->assertEquals(1, $DB->count_records('moodleoverflow_discuss_subs', [
             'userid' => $user->id,
             'discussion' => $discussion->id,
-        )));
+        ]));
     }
 
     /**
@@ -1422,7 +1422,7 @@ class subscriptions_test extends advanced_testcase {
         $this->resetAfterTest(true);
 
         // Create a guest user.
-        $guest = $DB->get_record('user', array('username' => 'guest'));
+        $guest = $DB->get_record('user', ['username' => 'guest']);
         $this->setUser($guest);
 
         // Create a course, with a moodleoverflow.

--- a/tests/userstats_test.php
+++ b/tests/userstats_test.php
@@ -183,7 +183,7 @@ class userstats_test extends \advanced_testcase {
 
         // User1 starts a new discussion, the forum activity shouldn't change.
         $discussion = $this->generator->post_to_forum($this->moodleoverflow, $this->user1);
-        $starterpost = $DB->get_record('moodleoverflow_posts', array('id' => $discussion[0]->firstpost), '*');
+        $starterpost = $DB->get_record('moodleoverflow_posts', ['id' => $discussion[0]->firstpost], '*');
         $newuserstats = $this->create_statstable();
         $newactivityuser1 = $this->get_specific_userstats($newuserstats, $this->user1, 'forumactivity');
         $this->assertEquals($oldactivityuser1, $newactivityuser1);
@@ -276,25 +276,25 @@ class userstats_test extends \advanced_testcase {
         global $DB;
         // Create a new course with a moodleoverflow forum.
         $this->course = $this->getDataGenerator()->create_course();
-        $location = array('course' => $this->course->id);
+        $location = ['course' => $this->course->id];
         $this->moodleoverflow = $this->getDataGenerator()->create_module('moodleoverflow', $location);
         $this->coursemodule = get_coursemodule_from_instance('moodleoverflow', $this->moodleoverflow->id);
 
         // Create a teacher.
-        $this->teacher = $this->getDataGenerator()->create_user(array('firstname' => 'Tamaro', 'lastname' => 'Walter'));
+        $this->teacher = $this->getDataGenerator()->create_user(['firstname' => 'Tamaro', 'lastname' => 'Walter']);
         $this->getDataGenerator()->enrol_user($this->teacher->id, $this->course->id, 'student');
 
         // Create 2 users and their discussions and posts.
-        $this->user1 = $this->getDataGenerator()->create_user(array('firstname' => 'Ava', 'lastname' => 'Davis'));
+        $this->user1 = $this->getDataGenerator()->create_user(['firstname' => 'Ava', 'lastname' => 'Davis']);
         $this->getDataGenerator()->enrol_user($this->user1->id, $this->course->id, 'student');
-        $this->user2 = $this->getDataGenerator()->create_user(array('firstname' => 'Ethan', 'lastname' => 'Brown'));
+        $this->user2 = $this->getDataGenerator()->create_user(['firstname' => 'Ethan', 'lastname' => 'Brown']);
         $this->getDataGenerator()->enrol_user($this->user2->id, $this->course->id, 'student');
 
         $this->generator = $this->getDataGenerator()->get_plugin_generator('mod_moodleoverflow');
         $this->discussion1 = $this->generator->post_to_forum($this->moodleoverflow, $this->user1);
         $this->discussion2 = $this->generator->post_to_forum($this->moodleoverflow, $this->user2);
-        $this->post1 = $DB->get_record('moodleoverflow_posts', array('id' => $this->discussion1[0]->firstpost), '*');
-        $this->post2 = $DB->get_record('moodleoverflow_posts', array('id' => $this->discussion1[0]->firstpost), '*');
+        $this->post1 = $DB->get_record('moodleoverflow_posts', ['id' => $this->discussion1[0]->firstpost], '*');
+        $this->post2 = $DB->get_record('moodleoverflow_posts', ['id' => $this->discussion1[0]->firstpost], '*');
         $this->answer1 = $this->generator->reply_to_post($this->discussion1[1], $this->user2, true);
         $this->answer2 = $this->generator->reply_to_post($this->discussion2[1], $this->user1, true);
     }
@@ -346,7 +346,7 @@ class userstats_test extends \advanced_testcase {
             'postid' => $post->id,
             'rating' => 2,
             'firstrated' => time(),
-            'lastchanged' => time()
+            'lastchanged' => time(),
         ];
         return $this->generator->create_rating($record);
     }
@@ -368,7 +368,7 @@ class userstats_test extends \advanced_testcase {
             'postid' => $post->id,
             'rating' => 1,
             'firstrated' => time(),
-            'lastchanged' => time()
+            'lastchanged' => time(),
         ];
         return $this->generator->create_rating($record);
     }
@@ -390,7 +390,7 @@ class userstats_test extends \advanced_testcase {
             'postid' => $post->id,
             'rating' => 4,
             'firstrated' => time(),
-            'lastchanged' => time()
+            'lastchanged' => time(),
         ];
         return $this->generator->create_rating($record);
     }
@@ -412,7 +412,7 @@ class userstats_test extends \advanced_testcase {
             'postid' => $post->id,
             'rating' => 3,
             'firstrated' => time(),
-            'lastchanged' => time()
+            'lastchanged' => time(),
         ];
         return $this->generator->create_rating($record);
     }

--- a/tracking.php
+++ b/tracking.php
@@ -34,12 +34,12 @@ $returnpage = optional_param('returnpage', 'index.php', PARAM_FILE); // The page
 require_sesskey();
 
 // Retrieve the moodleoverflow instance to track or untrack.
-if (!$moodleoverflow = $DB->get_record("moodleoverflow", array("id" => $id))) {
+if (!$moodleoverflow = $DB->get_record("moodleoverflow", ["id" => $id])) {
     throw new moodle_exception('invalidmoodleoverflowid', 'moodleoverflow');
 }
 
 // Retrieve the course of the instance.
-if (!$course = $DB->get_record("course", array("id" => $moodleoverflow->course))) {
+if (!$course = $DB->get_record("course", ["id" => $moodleoverflow->course])) {
     throw new moodle_exception('invalidcoursemodule');
 }
 
@@ -53,7 +53,7 @@ require_login($course, false, $cm);
 
 // Set the page to return to.
 $url = '/mod/moodleoverflow/' . $returnpage;
-$params = array('id' => $course->id, 'm' => $moodleoverflow->id);
+$params = ['id' => $course->id, 'm' => $moodleoverflow->id];
 $returnpageurl = new moodle_url($url, $params);
 $returnto = moodleoverflow_go_back_to($returnpageurl);
 
@@ -72,11 +72,11 @@ $info->name = fullname($USER);
 $info->moodleoverflow = format_string($moodleoverflow->name);
 
 // Set parameters for an event.
-$eventparams = array(
+$eventparams = [
     'context' => context_module::instance($cm->id),
     'relateduserid' => $USER->id,
-    'other' => array('moodleoverflowid' => $moodleoverflow->id),
-);
+    'other' => ['moodleoverflowid' => $moodleoverflow->id],
+];
 
 // Check whether the moodleoverflow is tracked.
 $istracked = \mod_moodleoverflow\readtracking::moodleoverflow_is_tracked($moodleoverflow);

--- a/userstats.php
+++ b/userstats.php
@@ -38,13 +38,13 @@ $mid = required_param('mid', PARAM_INT);             // Moodleoveflow ID, Moodle
 
 // Define important variables.
 if ($courseid) {
-    $course = $DB->get_record('course', array('id' => $courseid), '*');
+    $course = $DB->get_record('course', ['id' => $courseid], '*');
 }
 if ($cmid) {
     $cm = get_coursemodule_from_id('moodleoverflow', $cmid, $course->id, false, MUST_EXIST);
 }
 if ($mid) {
-    $moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $mid), '*');
+    $moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $mid], '*');
 }
 // Require a login.
 require_login($course, true, $cm);
@@ -56,8 +56,8 @@ $PAGE->set_context($context);
 // Do a capability check, in case a user iserts the userstats-url manually.
 if (has_capability('mod/moodleoverflow:viewanyrating', $context) && get_config('moodleoverflow', 'showuserstats')) {
     // Print the page header.
-    $PAGE->set_url('/mod/moodleoverflow/userstats.php', array('id' => $cm->id,
-    'courseid' => $course->id, 'mid' => $moodleoverflow->id));
+    $PAGE->set_url('/mod/moodleoverflow/userstats.php', ['id' => $cm->id,
+    'courseid' => $course->id, 'mid' => $moodleoverflow->id]);
     $PAGE->set_title(format_string('User statistics'));
     $PAGE->set_heading(format_string('User statistics of course: ' . $course->fullname));
 

--- a/version.php
+++ b/version.php
@@ -32,4 +32,4 @@ $plugin->version = 2023082500;
 $plugin->release = 'v4.2-r4';
 $plugin->requires = 2020061500; // Requires Moodle 3.9+.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->dependencies = array();
+$plugin->dependencies = [];

--- a/view.php
+++ b/view.php
@@ -38,7 +38,7 @@ $movetopopup = optional_param('movetopopup', 0, PARAM_INT);     // Which Topic t
 $linktoforum = optional_param('movetoforum', 0, PARAM_INT);     // Forum to which it is moved.
 
 // Set the parameters.
-$params = array();
+$params = [];
 if ($id) {
     $params['id'] = $id;
 } else {
@@ -52,18 +52,18 @@ $PAGE->set_url('/mod/moodleoverflow/view.php', $params);
 // Check for the course and module.
 if ($id) {
     $cm = get_coursemodule_from_id('moodleoverflow', $id, 0, false, MUST_EXIST);
-    $course = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
-    $moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $cm->instance), '*', MUST_EXIST);
+    $course = $DB->get_record('course', ['id' => $cm->course], '*', MUST_EXIST);
+    $moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $cm->instance], '*', MUST_EXIST);
 } else if ($m) {
-    $moodleoverflow = $DB->get_record('moodleoverflow', array('id' => $m), '*', MUST_EXIST);
-    $course = $DB->get_record('course', array('id' => $moodleoverflow->course), '*', MUST_EXIST);
+    $moodleoverflow = $DB->get_record('moodleoverflow', ['id' => $m], '*', MUST_EXIST);
+    $course = $DB->get_record('course', ['id' => $moodleoverflow->course], '*', MUST_EXIST);
     $cm = get_coursemodule_from_instance('moodleoverflow', $moodleoverflow->id, $course->id, false, MUST_EXIST);
 } else {
     throw new moodle_exception('missingparameter');
 }
 
 // Save the allowmultiplemarks setting.
-$marksetting = $DB->get_record('moodleoverflow', array('id' => $moodleoverflow->id), 'allowmultiplemarks');
+$marksetting = $DB->get_record('moodleoverflow', ['id' => $moodleoverflow->id], 'allowmultiplemarks');
 
 
 // Require a login.
@@ -79,14 +79,14 @@ if (!has_capability('mod/moodleoverflow:viewdiscussion', $context)) {
 }
 
 // Mark the activity completed (if required) and trigger the course_module_viewed event.
-$event = \mod_moodleoverflow\event\course_module_viewed::create(array(
+$event = \mod_moodleoverflow\event\course_module_viewed::create([
     'objectid' => $PAGE->cm->instance,
     'context' => $PAGE->context,
-));
+]);
 $event->trigger();
 
 // Print the page header.
-$PAGE->set_url('/mod/moodleoverflow/view.php', array('id' => $cm->id));
+$PAGE->set_url('/mod/moodleoverflow/view.php', ['id' => $cm->id]);
 $PAGE->set_title(format_string($moodleoverflow->name));
 $PAGE->set_heading(format_string($course->fullname));
 
@@ -101,7 +101,7 @@ echo $OUTPUT->header();
 if ($moodleoverflow->anonymous > 0) {
     $strkeys = [
             \mod_moodleoverflow\anonymous::QUESTION_ANONYMOUS => 'desc:only_questions',
-            \mod_moodleoverflow\anonymous::EVERYTHING_ANONYMOUS => 'desc:anonymous'
+            \mod_moodleoverflow\anonymous::EVERYTHING_ANONYMOUS => 'desc:anonymous',
     ];
     echo html_writer::tag('p', get_string($strkeys[$moodleoverflow->anonymous], 'moodleoverflow'));
 }
@@ -110,7 +110,7 @@ $reviewlevel = \mod_moodleoverflow\review::get_review_level($moodleoverflow);
 if ($reviewlevel > 0) {
     $strkeys = [
         \mod_moodleoverflow\review::QUESTIONS => 'desc:review_questions',
-        \mod_moodleoverflow\review::EVERYTHING => 'desc:review_everything'
+        \mod_moodleoverflow\review::EVERYTHING => 'desc:review_everything',
     ];
     echo html_writer::tag('p', get_string($strkeys[$reviewlevel], 'moodleoverflow'));
 }
@@ -132,7 +132,7 @@ if ($movetopopup && has_capability('mod/moodleoverflow:movetopic', $context)) {
 
 if ($linktoforum && $movetopopup && has_capability('mod/moodleoverflow:movetopic', $context)) {
     // Take the $movetopopup-id and the $linktoforum-id and move the discussion to the forum.
-    $topic = $DB->get_record('moodleoverflow_discussions', array('id' => $movetopopup));
+    $topic = $DB->get_record('moodleoverflow_discussions', ['id' => $movetopopup]);
     $topic->moodleoverflow = $linktoforum;
     $DB->update_record('moodleoverflow_discussions', $topic);
     redirect($CFG->wwwroot . '/mod/moodleoverflow/view.php?id=' . $cm->id);


### PR DESCRIPTION
The sorting bug is fixed. The problem were posts with the same amount of votes and upvotes, as there wasn't a sorting mechanism for that. The sorting algorithm is now improved and sorts posts:
- first after helpful/solved marks
- then after the amount of votes/upvotes
- at last after the time of creation/modification

Solves Issue: #172