### PR TITLE
Fix for single Activity format

### DIFF
--- a/index.php
+++ b/index.php
@@ -22,15 +22,13 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-global $CFG, $DB, $PAGE, $USER, $SESSION, $OUTPUT;
-
-// Require needed files.
-use core\context\course;
-
 require_once(dirname(dirname(dirname(__FILE__))) . '/config.php');
 global $CFG, $DB, $PAGE, $USER, $SESSION, $OUTPUT;
 require_once(dirname(__FILE__) . '/locallib.php');
 require_once($CFG->dirroot . '/course/lib.php');
+
+// Require needed files.
+use core\context\course;
 
 // Fetch submitted parameters.
 $id = required_param('id', PARAM_INT);

--- a/index.php
+++ b/index.php
@@ -21,7 +21,6 @@
  * @copyright 2017 Kennet Winter <k_wint10@uni-muenster.de>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-defined('MOODLE_INTERNAL') || die();
 
 global $CFG, $DB, $PAGE, $USER, $SESSION, $OUTPUT;
 

--- a/lib.php
+++ b/lib.php
@@ -464,10 +464,13 @@ function moodleoverflow_pluginfile($course, $cm, $context, $filearea, $args, $fo
  * This function is called when the context for the page is a moodleoverflow module. This is not called by AJAX
  * so it is safe to rely on the page variable.
  *
- * @param settings_navigation      $settingsnav        complete settings navigation tree
- * @param navigation_node|null     $moodleoverflownode moodleoverflow administration node
+ * @param settings_navigation $settingsnav complete settings navigation tree
+ * @param navigation_node|null $moodleoverflownode moodleoverflow administration node
+ * @throws \core\exception\moodle_exception
+ * @throws coding_exception
+ * @throws dml_exception
+ * @throws moodle_exception
  */
-
 function moodleoverflow_extend_settings_navigation(settings_navigation $settingsnav, navigation_node $moodleoverflownode = null) {
     global $DB, $USER;
 

--- a/lib.php
+++ b/lib.php
@@ -471,7 +471,7 @@ function moodleoverflow_pluginfile($course, $cm, $context, $filearea, $args, $fo
  * @throws dml_exception
  * @throws moodle_exception
  */
-function moodleoverflow_extend_settings_navigation(settings_navigation $settingsnav, navigation_node $moodleoverflownode = null) {
+function moodleoverflow_extend_settings_navigation(settings_navigation $settingsnav, ?navigation_node $moodleoverflownode = null) {
     global $DB, $USER;
 
     // Retrieve the current moodle record.


### PR DESCRIPTION
Fix for issue #197.

Bug: When creating a single activity course with moodleoverflow and going to "participant" within the course, an error occurs.

Problem: The lib function `moodleoverflow_extend_settings_navigation` uses the `$PAGE` variable to access certain variables like the context or the instance id of moodleoverflow. This does not work apparently, as a null exception is throwed.

Solution: Instead of using the global variable $PAGE, the function now uses a "local" page variable from the function parameter `$settingsnav` (The page variable is retrieved with `$settingsnav->get_page()`). This approach is used by other moodle plugin like the ratingallocate plugin from Learnweb.