### PR TITLE
Use $limitnum argument of get_records_sql to fix the MSSQL syntax issue

### DIFF
--- a/classes/review.php
+++ b/classes/review.php
@@ -107,20 +107,12 @@ class review {
             $addwhere = ' AND p.id != :notpostid ';
             $params['notpostid'] = $afterpostid;
         }
-        /* Handle different SQL dialects in favor of Microsoft SQL Server */
-        if (is_a($DB, 'sqlsrv_native_moodle_database')) {
-            $top = 'TOP 1';
-            $limit = '';
-        } else {
-            $top = '';
-            $limit = 'LIMIT 1';
-        }
         $record = $DB->get_record_sql(
-            "SELECT $top p.id as postid, p.discussion as discussionid FROM {moodleoverflow_posts} p " .
+            'SELECT p.id as postid, p.discussion as discussionid FROM {moodleoverflow_posts} p ' .
             'JOIN {moodleoverflow_discussions} d ON d.id = p.discussion ' .
             "WHERE p.reviewed = 0 AND d.moodleoverflow = :moodleoverflowid AND p.created < :reviewtime $addwhere " .
             "ORDER BY $orderby p.discussion, p.id " .
-            $limit,
+            'LIMIT 1',
             $params
         );
         if ($record) {

--- a/classes/review.php
+++ b/classes/review.php
@@ -107,18 +107,20 @@ class review {
             $addwhere = ' AND p.id != :notpostid ';
             $params['notpostid'] = $afterpostid;
         }
-        $record = $DB->get_record_sql(
+        $records = $DB->get_records_sql(
             'SELECT p.id as postid, p.discussion as discussionid FROM {moodleoverflow_posts} p ' .
             'JOIN {moodleoverflow_discussions} d ON d.id = p.discussion ' .
             "WHERE p.reviewed = 0 AND d.moodleoverflow = :moodleoverflowid AND p.created < :reviewtime $addwhere " .
-            "ORDER BY $orderby p.discussion, p.id " .
-            'LIMIT 1',
-            $params
+            "ORDER BY $orderby p.discussion, p.id ",
+            $params,
+            0,
+            1
         );
-        if ($record) {
+        $key = array_key_first($records);
+        if ($key) {
             return (new \moodle_url('/mod/moodleoverflow/discussion.php', [
-                'd' => $record->discussionid,
-            ], 'p' . $record->postid))->out(false);
+                'd' => $records[$key]->discussionid,
+            ], 'p' . $records[$key]->postid))->out(false);
         } else {
             return null;
         }


### PR DESCRIPTION
#101 proposed a fix for a SQL query that used syntax not known to MSSQL. This fix is not database-agnostic. The present PR provides a database-agnostic solution to the problem.