### PR TITLE
Hotfix for anonymous Mail

### DIFF
--- a/classes/output/moodleoverflow_email.php
+++ b/classes/output/moodleoverflow_email.php
@@ -358,7 +358,7 @@ class moodleoverflow_email implements \renderable, \templatable {
      * @return string
      */
     public function get_author_fullname() {
-        if (anonymous::is_post_anonymous($this->discussion, $this->moodleoverflow, $this->author->id)) {
+        if ($this->author->anonymous) {
             return get_string('privacy:anonym_user_name', 'mod_moodleoverflow');
         } else {
             return fullname($this->author, $this->viewfullnames);
@@ -521,7 +521,7 @@ class moodleoverflow_email implements \renderable, \templatable {
      * @return string
      */
     public function get_authorlink() {
-        if (anonymous::is_post_anonymous($this->discussion, $this->moodleoverflow, $this->author->id)) {
+        if ($this->author->anonymous) {
             return null;
         }
 
@@ -542,7 +542,7 @@ class moodleoverflow_email implements \renderable, \templatable {
      */
     public function get_author_picture() {
         global $OUTPUT;
-        if (anonymous::is_post_anonymous($this->discussion, $this->moodleoverflow, $this->author->id)) {
+        if ($this->author->anonymous) {
             return '';
         }
 
@@ -555,7 +555,7 @@ class moodleoverflow_email implements \renderable, \templatable {
      * @return string
      */
     public function get_group_picture() {
-        if (anonymous::is_post_anonymous($this->discussion, $this->moodleoverflow, $this->author->id)) {
+        if ($this->author->anonymous) {
             return '';
         }
 

--- a/classes/task/send_mails.php
+++ b/classes/task/send_mails.php
@@ -25,6 +25,7 @@
 namespace mod_moodleoverflow\task;
 
 use core\session\exception;
+use mod_moodleoverflow\anonymous;
 use mod_moodleoverflow\output\moodleoverflow_email;
 
 defined('MOODLE_INTERNAL') || die();
@@ -122,6 +123,7 @@ class send_mails extends \core\task\scheduled_task {
 
             $post = $postinfo;
             $userfrom = \core_user::get_user($postinfo->userid, '*', MUST_EXIST);
+            $userfrom->anonymous = anonymous::is_post_anonymous($discussion, $moodleoverflow, $postinfo->userid);
 
             foreach ($usersto as $userto) {
                 try {

--- a/externallib.php
+++ b/externallib.php
@@ -22,6 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use mod_moodleoverflow\anonymous;
 use mod_moodleoverflow\output\moodleoverflow_email;
 use mod_moodleoverflow\review;
 
@@ -121,7 +122,7 @@ class mod_moodleoverflow_external extends external_api {
         $ownerrating = \mod_moodleoverflow\ratings::moodleoverflow_get_reputation($moodleoverflow->id, $postownerid);
         $raterrating = \mod_moodleoverflow\ratings::moodleoverflow_get_reputation($moodleoverflow->id, $USER->id);
 
-        $cannotseeowner = \mod_moodleoverflow\anonymous::is_post_anonymous($discussion, $moodleoverflow, $USER->id) &&
+        $cannotseeowner = anonymous::is_post_anonymous($discussion, $moodleoverflow, $USER->id) &&
             $USER->id != $postownerid;
 
         $params['postrating'] = $rating->upvotes - $rating->downvotes;
@@ -254,6 +255,7 @@ class mod_moodleoverflow_external extends external_api {
         $renderertext = $PAGE->get_renderer('mod_moodleoverflow', 'email', 'textemail');
 
         $userto = core_user::get_user($post->userid);
+        $userto->anonymous = anonymous::is_post_anonymous($discussion, $moodleoverflow, $post->userid);
 
         $maildata = new moodleoverflow_email(
                 $course,

--- a/lib.php
+++ b/lib.php
@@ -820,10 +820,12 @@ function moodleoverflow_send_mails() {
 
                 if (\mod_moodleoverflow\anonymous::is_post_anonymous($discussion, $moodleoverflow, $post->userid)) {
                     $userfrom = \core_user::get_noreply_user();
+                    $userfrom->anonymous = true;
                 } else {
                     // Check whether the sending user is cached already.
                     if (array_key_exists($post->userid, $users)) {
                         $userfrom = $users[$post->userid];
+                        $userfrom->anonymous = false;
                     } else {
                         // We dont know the the user yet.
 
@@ -831,6 +833,7 @@ function moodleoverflow_send_mails() {
                         $userfrom = $DB->get_record('user', ['id' => $post->userid]);
                         if ($userfrom) {
                             moodleoverflow_minimise_user_record($userfrom);
+                            $userfrom->anonymous = false;
                         } else {
                             $uid = $post->userid;
                             $pid = $post->id;
@@ -1093,7 +1096,7 @@ function moodleoverflow_mark_old_posts_as_mailed($endtime) {
  *
  * @param stdClass $user
  */
-function moodleoverflow_minimise_user_record(stdClass $user) {
+function moodleoverflow_minimise_user_record(stdClass &$user) {
 
     // Remove all information for the mail generation that are not needed.
     unset($user->institution);

--- a/templates/email_text.mustache
+++ b/templates/email_text.mustache
@@ -72,7 +72,7 @@
 {{{ coursename }}} -> {{#str}} moodleoverflows, moodleoverflow {{/str}} -> {{{ moodleoverflowname }}}{{#showdiscussionname}} -> {{{ discussionname }}} {{/showdiscussionname}}
 {{ permalink }}
 {{{ subject }}}
-{{#str}} bynameondate, moodleoverflow, {
+{{#str}} bynameondatenorating, moodleoverflow, {
 "name": {{#quote}}{{{ authorfullname }}}{{/quote}},
 "date": {{#quote}}{{ postdate }}{{/quote}}
 } {{/str}}

--- a/version.php
+++ b/version.php
@@ -29,6 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_moodleoverflow';
 $plugin->version   = 2025050600;
+$plugin->version = 2025051700;
 $plugin->requires  = 2022112800;
 $plugin->release = 'v4.5-r1';
 $plugin->supported = [401, 405];


### PR DESCRIPTION
Fixes problem adressed in #211, #202.

What was the problem?
It was a really funny problem. In the process of sending a notification mail of a new post, it's being checked twice (in different files and contexts) if the author of the post should be anonymous. Both checks function perfectly. The problem was, that the algorithm set a user-id to a negative integer after a first successful anonymous check.The second check works with the changed user-id integer and compares it to the original post user-id. Since the user-ids are not equal, the user was wrongly set as "non-anonymous". This happened especially in half-anonymous forums, as in those the anonymous status is being checked by user-id.

What is the solution?
After the first check, the anonymous status of the author is being saved in a variable. The second anonymous check is being replaced by simply checking the previous set variable.

Important!
This is only a hotfix. The email-system still needs a redesign that can be followed on #212.