### PR TITLE
Fix: mark post as read, deleting posts

### DIFF
--- a/markposts.php
+++ b/markposts.php
@@ -21,12 +21,10 @@
  * @copyright 2017 Kennet Winter <k_wint10@uni-muenster.de>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-defined('MOODLE_INTERNAL') || die();
+
+require_once('../../config.php');
 
 global $CFG, $DB, $PAGE, $USER, $SESSION, $OUTPUT;
-
-// We do not need the locallib here.
-require_once('../../config.php');
 require_once($CFG->dirroot . '/mod/moodleoverflow/locallib.php');
 
 // Define the parameters.


### PR DESCRIPTION
> **Note:** Please fill out all required sections and remove irrelevant ones.
### 🔀 Purpose of this PR:

- [x] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [ ] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

The markposts.php had a moodle internal check that prevents direct access to the page. But due to this, when clicking on the trash bin in the discussion list, posts were not marked as "read".

Solution: The moodle internal was removed. As there was an additional import of the config.php, no code guidelines are violated. Directly accessing the page was never possible because of capability checks and other security measures.
---

### 📋 Checklist

Please confirm the following (check all that apply):

- [x] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.

---

### 🔍 Related Issues

- This fixes a part of Issue #216

---

### 🧾📸🌐 Additional Information (like screenshots, documentation, links, etc.)

Any other relevant information.

---