### PR TITLE
Fix exception when editing a post

### DIFF
--- a/classes/anonymous.php
+++ b/classes/anonymous.php
@@ -65,7 +65,7 @@ class anonymous {
         }
 
         if ($moodleoverflow->anonymous == self::QUESTION_ANONYMOUS) {
-            return $discussion->userid == $postinguserid;
+            return $discussion->get_userid() == $postinguserid;
         }
 
         return false;


### PR DESCRIPTION
> **Note:** Please fill out all relevant sections and remove irrelevant ones.
### 🔀 Purpose of this PR:

- [x] Fixes a bug

---

### 📝 Description:

- When editing a post, we get an exception with the following stack trace:

```
Cannot access private property mod_moodleoverflow\discussion\discussion::$userid

line 69 of /mod/moodleoverflow/classes/anonymous.php: Error thrown
line 582 of /mod/moodleoverflow/classes/post/post_control.php: call to mod_moodleoverflow\anonymous::is_post_anonymous()
line 125 of /mod/moodleoverflow/post.php: call to mod_moodleoverflow\post\post_control->build_postform() 
```

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [ ] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that should not appear on the productive branch.
- [ ] I ran all tests thoroughly checking for errors. I checked if bootstrap had any changes/deprecations that require changes in the plugins UI.