### PR TITLE
Fix button that marks all posts as read

### DIFF
--- a/classes/readtracking.php
+++ b/classes/readtracking.php
@@ -130,7 +130,7 @@ class readtracking {
         $discussions = moodleoverflow_get_discussions_unread($cm);
 
         // Iterate through all of this discussions.
-        foreach ($discussions as $discussionid) {
+        foreach ($discussions as $discussionid => $unread) {
             // Mark the discussion as read.
             $markedcheck = self::moodleoverflow_mark_discussion_read($discussionid, context_module::instance($cm->id), $userid);
             moodleoverflow_throw_exception_with_check($markedcheck !== true, 'markreadfailed');


### PR DESCRIPTION
### 🔀 Purpose of this PR:

- [x] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [ ] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

The issue #230 described the problem that the "mark all posts as read" button did not perform its intended function. Instead of marking posts as read, the button had no effect.

What was the problem?
The function responsible for marking all posts in moodleoverflow as read  (readtracking::moodleoverflow_mark_moodleoverflow_read() ) iterates through the unread discussions of a user. These unread discussions are stored in an associative array of the form:
 `$discussions = [discussionID => amount_of_unread_posts]`.
However, the loop incorrectly iterated over the values (number of unread posts) instead of the keys (discussion IDs):
```
foreach ($discussions as $discussionid) {...}
``` 

What is the solution?
Iterate the right way over the array, explicitly using the key:
```
foreach ($discussions as $discussionid => $unread) {...}
```
---

### 📋 Checklist

Please confirm the following (check all that apply):

- [ ] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.
- [ ] If there are changes in the database: I updated/created the necessary upgrade steps in `db/upgrade.php` and
  updated the `version.php`.
- [ ] If there are changes in javascript: I build new `.min` files with the `grunt amd` command.
- [ ] If it is a Moodle update PR: I read the release notes, updated the `version.php` and the `CHANGES.md`.
  I ran all tests thoroughly checking for errors. I checked if bootstrap had any changes/deprecations that require
  changes in the plugins UI.

---

### 🔍 Related Issues

- Related to #230
