### PR TITLE
Fix bug when editing own posts in anonymous mode 

### DIFF
--- a/classes/post/post_control.php
+++ b/classes/post/post_control.php
@@ -464,8 +464,8 @@ class post_control {
         $event->trigger();
 
         // Subscribe to this thread.
-        // Please be aware that in future the use of build_db_object() should be replaced with only $this->info->discussion,
-        // as the subscription class should be refactored with the new way of working with posts.
+        // LEARNWEB-TODO: Please be aware that in future the use of build_db_object() should be replaced with only
+        // $this->info->discussion, as the subscription class should be refactored with the new way of working with posts.
         subscriptions::moodleoverflow_post_subscription(
             $form,
             $this->info->moodleoverflow,
@@ -611,9 +611,11 @@ class post_control {
         );
 
         // If the post is anonymous, attachments should have an anonymous author when editing the attachment.
+        // LEARNWEB-TODO: Please be aware that in future the use of build_db_object() should be replaced with only
+        // $this->info->discussion, when the new way of working with posts is fully implemented.
         if (
             $draftitemid && $this->interaction == 'edit' && anonymous::is_post_anonymous(
-                $this->info->discussion,
+                $this->info->discussion->get_db_object(),
                 $this->info->moodleoverflow,
                 $this->prepost->userid
             )


### PR DESCRIPTION
### 🔀 Purpose of this PR:

- [x] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [ ] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

As described in #228, in an "only questioners"-anonymous mode, when a user wanted to edit a post, an error ocurred an the editing was not possible.

**What was the problem?**
When checking if a post is anonymous, the `post_control` class sends the `$info->discussion` with an instance of the `discussion` class to the `is_post_anonymous` function. The function although expects a simple stdClass-object and tries to read a private-accessible attribute of the class.

**What is the solution?**
The `discussion` class is part of the new posts and discussion structure, that is not implemented in all parts of the plugin. Because of that, some functions work with the old system and the new one. A simple solution so far is the function `get_db_object` from the discussion class that returns a simple stdClass with the database-attributes of the object, that every function can work with. A To-Do was added for further development.

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [ ] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.
- [ ] If there are changes in the database: I updated/created the necessary upgrade steps in `db/upgrade.php` and
  updated the `version.php`.
- [ ] If there are changes in javascript: I build new `.min` files with the `grunt amd` command.
- [ ] If it is a Moodle update PR: I read the release notes, updated the `version.php` and the `CHANGES.md`.
  I ran all tests thoroughly checking for errors. I checked if bootstrap had any changes/deprecations that require
  changes in the plugins UI.

---

### 🔍 Related Issues

- Related to #228 
