### PR TITLE
Fix for userstats SQL

### DIFF
--- a/classes/tables/userstats_table.php
+++ b/classes/tables/userstats_table.php
@@ -263,7 +263,7 @@ class userstats_table extends \flexible_table {
      */
     private function get_rating_data() {
         global $DB;
-        $sqlquery = 'SELECT (ROW_NUMBER() OVER (ORDER BY ratings.id)) AS row_num,
+        $sqlquery = 'SELECT ROW_NUMBER() OVER (ORDER BY ratings.id) AS row_num,
                             discuss.id AS discussid,
                             discuss.userid AS discussuserid,
                             posts.id AS postid,


### PR DESCRIPTION
### 🔀 Purpose of this PR:

- [x] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [ ] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

This is an fix for #164. The error is that when opening the user statistics an SQL syntax error occurred on some systems.

What was the error?
In the SQL statement is an extra parenthesis, that on some moodle/mysql-version get not parsed correctly.

What is the solution?
As the parenthesis were unnecessary, they could just be removed from the SQL-statement

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [x] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.

---

### 🔍 Related Issues

- Related to #164 
