### PR TITLE
Fix missing grade category on import

### DIFF
--- a/backup/moodle2/backup_moodleoverflow_stepslib.php
+++ b/backup/moodle2/backup_moodleoverflow_stepslib.php
@@ -130,6 +130,7 @@ class backup_moodleoverflow_activity_structure_step extends backup_activity_stru
         $read->annotate_ids('user', 'userid');
         $rating->annotate_ids('user', 'userid');
         $track->annotate_ids('user', 'userid');
+        $moodleoverflow->annotate_ids('grade_category', 'gradecat');
 
         // Define file annotations (we do not use itemid in this example).
         $moodleoverflow->annotate_files('mod_moodleoverflow', 'intro', null);

--- a/backup/moodle2/restore_moodleoverflow_stepslib.php
+++ b/backup/moodle2/restore_moodleoverflow_stepslib.php
@@ -97,6 +97,11 @@ class restore_moodleoverflow_activity_structure_step extends restore_activity_st
             $data->timemodified = time();
         }
 
+        if (!empty($data->gradecat)) {
+            // Map grade category.
+            $data->gradecat = $this->get_mappingid('grade_category', $data->gradecat);
+        }
+
         // Create the moodleoverflow instance.
         $newitemid = $DB->insert_record('moodleoverflow', $data);
         $this->apply_activity_instance($newitemid);


### PR DESCRIPTION
> **Note:** Please fill out all relevant sections and remove irrelevant ones.
### 🔀 Purpose of this PR:

- [x] Fixes a bug

---

### 📝 Description:

This PR fixes #204, where after a import of a moodleoverflow, a set grade category was not in the imported moodleoverflow. The situation was:
In a course with grade category `gradecat` and a moodleoverflow with this grade category set, after importing the course into another course, the grade category was imported but the moodleoverflow did not and it was not possible to reassign it to the grade category.

What was the problem?

In the `backup_moodleoverflow_stepslib.php` the grade category id was not saved for a backup and in the `restore_moodleoverflow_stepslib.php` a saved grade category was not reassigned to the moodleoverflow.


What is the solution?

Annotate the grade category in the backup_stepslib and reassign it in the restore_stepslib. After that the grade category can be set in the moodleoverflow settings to `gradecat`.
---

### 📋 Checklist

Please confirm the following (check all that apply):

- [ ] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.
---

### 🔍 Related Issues

- Related to #204 

---