### PR TITLE
Hide move button if only one instance is present in the course

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -226,7 +226,12 @@ function moodleoverflow_print_latest_discussions($moodleoverflow, $cm, $page = -
     // Check wether the user can move a topic.
     $canmovetopic = false;
     if ((!is_guest($context, $USER) && isloggedin()) && has_capability('mod/moodleoverflow:movetopic', $context)) {
-        $canmovetopic = true;
+        $modinfo = get_fast_modinfo($moodleoverflow->course);
+        $coursemoodleoverflows = $modinfo->get_instances_of('moodleoverflow');
+        $coursemoodleoverflows = array_filter($coursemoodleoverflows, function($cm) {
+            return $cm->deletioninprogress == 0;
+        });
+        $canmovetopic = count($coursemoodleoverflows) > 1;
     }
 
     // Iterate through every visible discussion.


### PR DESCRIPTION
### 🔀 Purpose of this PR:

- [X] Fixes a bug

---

### 📝 Description:

This PR fixes issue #237 . The move button was displayed even if there were no other Moodleoverflow instances in the course to move to.
---

### 📋 Checklist

Please confirm the following (check all that apply):

- [ ] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [X] Code passes the code checker without errors and warnings.
- [X] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [X] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [X] Code only uses language strings instead of hard-coded strings.

---

### 🔍 Related Issues

- Related to #237 
