### PR TITLE
Fix icon size

### DIFF
--- a/index.php
+++ b/index.php
@@ -31,6 +31,7 @@ require_once($CFG->dirroot . '/course/lib.php');
 
 // Require needed files.
 use core\context\course;
+use core\output\pix_icon;
 
 // Fetch submitted parameters.
 $id = required_param('id', PARAM_INT);
@@ -255,7 +256,7 @@ if ($generalmoodleoverflows) {
                     $unreadlink .= '<a title="' . $string['markallread'] . '" href="markposts.php?m=' . $moodleoverflow->id .
                         '&amp;mark=read&amp;sesskey=' . sesskey() . '">';
                     $unreadlink .= '<img src="' . $OUTPUT->image_url('t/markasread') . '" alt="' .
-                        $string['markallread'] . '" class="iconsmall" />';
+                        $string['markallread'] . '" class="icon iconsmall" />';
                     $unreadlink .= '</a>';
                     $unreadlink .= '</span>';
                 } else {


### PR DESCRIPTION
### 🔀 Purpose of this PR:

- [X] Fixes a bug

---

### 📝 Description:

Icon size of the button to mark all posts read is huge - adding icon class to resize the button.

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [X] Code passes the code checker without errors and warnings.
- [X] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [X] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.

---
