### PR TITLE
Ignore instances with deletion in progress

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -460,6 +460,8 @@ function moodleoverflow_print_forum_list($course, $cm, $movetopopup) {
     $forumarray = [[]];
     $currentforum = $DB->get_record('moodleoverflow_discussions', ['id' => $movetopopup], 'moodleoverflow');
     $currentdiscussion = $DB->get_record('moodleoverflow_discussions', ['id' => $movetopopup], 'name');
+    $modinfo = get_fast_modinfo($course->id);
+    $instances = $modinfo->get_instances_of('moodleoverflow');
 
     // If the currentforum is anonymous, only show forums that have a higher anonymous setting.
     $anonymoussetting = $DB->get_field('moodleoverflow', 'anonymous', ['id' => $currentforum->moodleoverflow]);
@@ -480,17 +482,20 @@ function moodleoverflow_print_forum_list($course, $cm, $movetopopup) {
 
     if ($amountforums >= 1) {
         // Write the moodleoverflow-names in an array.
-        $i = 0;
         foreach ($forums as $forum) {
             if ($forum->id == $currentforum->moodleoverflow) {
                 continue;
-            } else {
-                $forumarray[$i]['name'] = $forum->name;
-                $movetoforum = $CFG->wwwroot . '/mod/moodleoverflow/view.php?id=' . $cm->id . '&movetopopup='
-                                             . $movetopopup . '&movetoforum=' . $forum->id;
-                $forumarray[$i]['movetoforum'] = $movetoforum;
+            } else if (empty($instances[$forum->id]->deletioninprogress)) {
+                $movetourl = new moodle_url('/mod/moodleoverflow/view.php', [
+                    'id' => $cm->id,
+                    'movetopopup' => $movetopopup,
+                    'movetoforum' => $forum->id,
+                ]);
+                $forumarray[] = [
+                    'name' => $forum->name,
+                    'movetoforum' => $movetourl->out(false),
+                ];
             }
-            $i++;
         }
         $amountforums = true;
     } else {


### PR DESCRIPTION
> **Note:** Please fill out all relevant sections and remove irrelevant ones.
### 🔀 Purpose of this PR:

- [X] Fixes a bug

---

### 📝 Description:

If you have Moodleoverflow instances that are currently being deleted, they are still shown as targets to move posts to. This PR hides them from the list.

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [X] Code passes the code checker without errors and warnings.
- [X] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [X] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.

---
