### PR TITLE
Align icons

### DIFF
--- a/templates/post.mustache
+++ b/templates/post.mustache
@@ -61,6 +61,8 @@
         {{/needsreview}}
             <div class="status moodleoverflow-icon-no-margin">
                     <span class="onlyifsolved">{{#pix}} i/status-solved, moodleoverflow, {{#str}}ratedbyteacher, moodleoverflow{{/str}} {{/pix}}</span>
+            </div>
+            <div class="status moodleoverflow-icon-no-margin">
                     <span class="onlyifhelpful">{{#pix}} i/status-helpful, moodleoverflow, {{#str}}ratedbystarter, moodleoverflow{{/str}} {{/pix}}</span>
             </div>
         </div>


### PR DESCRIPTION
### 🔀 Purpose of this PR:

- [X] Fixes a bug

---

### 📝 Description:

If you have enabled marking as helpful and as a solution at the same time, the icons are displayed side by side at the post and are not aligned to the upvote / downvote icons above them. The PR fixes this.

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [X] Code passes the code checker without errors and warnings.
- [X] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [X] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
