### PR TITLE
Wrap discussion creation into db transaction

### DIFF
--- a/classes/models/discussion.php
+++ b/classes/models/discussion.php
@@ -186,46 +186,57 @@ class discussion {
      */
     public function moodleoverflow_add_discussion(object $prepost): bool|int|null {
         global $DB;
+        try {
+            $transaction = $DB->start_delegated_transaction();
 
-        // Add the discussion to the Database.
-        $this->id = $DB->insert_record('moodleoverflow_discussions', $this->build_db_object());
+            // Add the discussion to the Database.
+            $this->id = $DB->insert_record('moodleoverflow_discussions', $this->build_db_object());
 
-        // Create the first/parent post for the new discussion and add it do the DB.
-        $post = post::construct_without_id(
-            $this->id,
-            0,
-            $prepost->userid,
-            $prepost->timenow,
-            $prepost->timenow,
-            $prepost->message,
-            $prepost->messageformat,
-            "",
-            0,
-            $prepost->reviewed,
-            null,
-            $prepost->formattachments
-        );
-        // Add it to the DB and save the id of the first/parent post.
-        $this->firstpost = $post->moodleoverflow_add_new_post();
+            // Create the first/parent post for the new discussion and add it to the DB.
+            $post = post::construct_without_id(
+                $this->id,
+                0,
+                $prepost->userid,
+                $prepost->timenow,
+                $prepost->timenow,
+                $prepost->message,
+                $prepost->messageformat,
+                "",
+                0,
+                $prepost->reviewed,
+                null,
+                $prepost->formattachments
+            );
 
-        // Save the id of the first/parent post in the DB.
-        $DB->set_field('moodleoverflow_discussions', 'firstpost', $this->firstpost, ['id' => $this->id]);
+            // Add it to the DB and save the id of the first/parent post.
+            $this->firstpost = $post->moodleoverflow_add_new_post();
+            $DB->set_field('moodleoverflow_discussions', 'firstpost', $this->firstpost, ['id' => $this->id]);
 
-        // Add the parent post to the $posts array.
-        $this->posts[$this->firstpost] = $post;
-        $this->postsbuild = true;
+            // Add the parent post to the $posts array.
+            $this->posts[$this->firstpost] = $post;
+            $this->postsbuild = true;
 
-        // Trigger event.
-        $params = [
-            'context' => $prepost->modulecontext,
-            'objectid' => $this->id,
-        ];
-        // LEARNWEB-TODO: check if the event functions.
-        $event = discussion_viewed::create($params);
-        $event->trigger();
+            // Trigger event.
+            $params = [
+                'context' => $prepost->modulecontext,
+                'objectid' => $this->id,
+            ];
+            // LEARNWEB-TODO: check if the event functions.
+            $event = discussion_viewed::create($params);
+            $event->trigger();
 
-        // Return the id of the discussion.
-        return $this->id;
+            // Everything worked, commit the transaction.
+            $transaction->allow_commit();
+
+            // Return the id of the discussion.
+            return $this->id;
+        } catch (Exception $e) {
+            // Something went wrong, roll back every change so no half-created discussion remains.
+            $transaction->rollback($e);
+        }
+
+        // Adding the discussion has failed.
+        return false;
     }
 
     /**


### PR DESCRIPTION
### 🔀 Purpose of this PR:

- [x] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [ ] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

The problem: the creation of a new discussion always involves the creation of the first post:

```
create discussion and save into db
create post and save into db
update discussion->firstpost reference to the recently created post 
```
If something goes wrong while saving the post into the db, both enitites are saved but the reference to the first post of the discussion does not get updated and stays in a bad state and lost from the discussion view.


The fix: wrapping the discussion creation + firstpost creation + firstpost update into an database transaction ensures that either everything goes correctly or the creation of the discussions fails and needs to be retried.

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [x] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.


---

### 🔍 Related Issues

- Related to #274 
