### PR TITLE
Fix bug in review functionality

### DIFF
--- a/classes/models/post.php
+++ b/classes/models/post.php
@@ -177,7 +177,7 @@ class post {
         $messageformat = !empty($record->messageformat) ? $record->messageformat : 0;
         $attachment = !empty($record->attachment) ? $record->attachment : '';
         $mailed = !empty($record->mailed) ? $record->mailed : 0;
-        $reviewed = !empty($record->reviewed) ? $record->reviewed : 1;
+        $reviewed = $record->reviewed ?? 1;
         $timereviewed = !empty($record->timereviewed) ? $record->timereviewed : null;
 
         return new self(

--- a/db/services.php
+++ b/db/services.php
@@ -35,9 +35,9 @@ $functions = [
         'capabilities' => 'mod/moodleoverflow:ratepost',
     ],
     'mod_moodleoverflow_review_approve_post' => [
-        'classname' => 'mod_moodleoverflow\external\approve_post',
+        'classname' => 'mod_moodleoverflow\external\review_approve_post',
         'methodname' => 'execute',
-        'classpath' => 'mod/moodleoverflow/classes/external/approve_post.php',
+        'classpath' => 'mod/moodleoverflow/classes/external/review_approve_post.php',
         'description' => 'Approves a post',
         'type' => 'write',
         'ajax' => true,

--- a/tests/behat/behat_mod_moodleoverflow.php
+++ b/tests/behat/behat_mod_moodleoverflow.php
@@ -32,6 +32,7 @@ use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
 use mod_moodleoverflow\post\post_control;
 use mod_moodleoverflow\readtracking;
+use mod_moodleoverflow\review;
 use mod_moodleoverflow\subscriptions;
 
 /**
@@ -134,6 +135,88 @@ class behat_mod_moodleoverflow extends behat_base {
             'message' => 'Answer from student', 'messageformat' => 1, 'attachment' => '', 'mailed' => 1, 'reviewed' => '1',
             'timereviewed' => null,
         ]);
+    }
+
+    /**
+     * Build a background to test the reviewing (approve/reject) feature.
+     * Builds:
+     * - A course with one teacher and one student, both enrolled.
+     * - A moodleoverflow that requires every new post to be reviewed.
+     * - A discussion started by the teacher whose first post is already reviewed.
+     * - A reply by the student that is still pending review.
+     *
+     * The student post is created in the past so that it is already past the review waiting
+     * period (reviewpossibleaftertime), which makes the approve/reject buttons show immediately.
+     *
+     * @Given /^I set up a moodleoverflow with a student post pending review$/
+     * @return void
+     */
+    public function i_set_up_a_moodleoverflow_with_a_student_post_pending_review(): void {
+        global $DB;
+
+        $this->i_prepare_a_moodleoverflow_background(new TableNode([
+            ['username', 'firstname', 'lastname', 'email', 'idnumber', 'role'],
+            ['teacher1', 'Tamaro', 'Walter', 'tamaro@mail.com', '10', 'teacher'],
+            ['student1', 'John', 'Smith', 'john@mail.com', '11', 'student'],
+        ]));
+
+        $course = $DB->get_record('course', ['shortname' => 'C1']);
+        $teacher = $DB->get_record('user', ['username' => 'teacher1']);
+        $student = $DB->get_record('user', ['username' => 'student1']);
+        $time = time();
+        // Age the pending post so it is past the review waiting period and the review buttons are shown.
+        $pasttime = $time - DAYSECS;
+
+        // Create a moodleoverflow that requires every post to be reviewed.
+        $this->execute('behat_data_generators::the_following_entities_exist', ['activities', new TableNode([
+            ['activity', 'course', 'name', 'needsreview'],
+            ['moodleoverflow', 'C1', 'Moodleoverflow 1', review::EVERYTHING],
+        ])]);
+        $moodleoverflow = $DB->get_record('moodleoverflow', ['name' => 'Moodleoverflow 1']);
+
+        // Create the discussion with the teacher's already reviewed first post.
+        $discussionid = $DB->insert_record('moodleoverflow_discussions', ['course' => $course->id,
+            'moodleoverflow' => $moodleoverflow->id, 'name' => 'Discussion 1', 'firstpost' => 1, 'userid' => $teacher->id,
+            'timemodified' => $time, 'timestart' => $time, 'usermodified' => $teacher->id,
+        ]);
+        $teacherpostid = $DB->insert_record('moodleoverflow_posts', ['discussion' => $discussionid,
+            'moodleoverflow' => $moodleoverflow->id, 'parent' => 0, 'userid' => $teacher->id, 'created' => $time,
+            'modified' => $time, 'message' => 'Message from teacher', 'messageformat' => 1, 'attachment' => '', 'mailed' => 1,
+            'reviewed' => 1, 'timereviewed' => $time,
+        ]);
+
+        // Update firstpost field in discussion.
+        $record = $DB->get_record('moodleoverflow_discussions', ['id' => $discussionid]);
+        $record->firstpost = $teacherpostid;
+        $DB->update_record('moodleoverflow_discussions', $record);
+
+        // Create the student reply that is still pending review.
+        $DB->insert_record('moodleoverflow_posts', ['discussion' => $discussionid, 'moodleoverflow' => $moodleoverflow->id,
+            'parent' => $teacherpostid, 'userid' => $student->id, 'created' => $pasttime, 'modified' => $pasttime,
+            'message' => 'Answer from student', 'messageformat' => 1, 'attachment' => '', 'mailed' => 1, 'reviewed' => 0,
+            'timereviewed' => null,
+        ]);
+    }
+
+    /**
+     * Clicks a moodleoverflow review action button (e.g. "approve", "reject", "reject-submit").
+     *
+     * The button is scrolled into the centre of the viewport first so that it is not covered by
+     * sticky page elements such as the course activity navigation footer, which would otherwise
+     * intercept the click.
+     *
+     * @When /^I click on the "(?P<action_string>[^"]*)" moodleoverflow review button$/
+     * @param string $action The value of the data-moodleoverflow-action attribute.
+     * @return void
+     */
+    public function i_click_on_the_moodleoverflow_review_button(string $action): void {
+        $selector = "[data-moodleoverflow-action='" . $action . "']";
+        $node = $this->find('css', $selector);
+        $this->getSession()->executeScript(
+            "document.querySelector(\"" . $selector . "\").scrollIntoView({block: 'center'});"
+        );
+        $this->ensure_node_is_visible($node);
+        $node->click();
     }
 
     /**

--- a/tests/behat/review_post.feature
+++ b/tests/behat/review_post.feature
@@ -1,0 +1,25 @@
+@mod @mod_moodleoverflow @javascript
+Feature: Teachers can review posts in a moodleoverflow that requires reviewing
+  In order to control which posts become visible
+  As a teacher
+  I need to approve or reject posts that are pending review
+
+  Background:
+    Given I set up a moodleoverflow with a student post pending review
+
+  Scenario: A teacher approves a student post that is pending review
+    Given I navigate as "teacher1" to "Course 1" "Moodleoverflow 1" "Discussion 1"
+    Then I should see "Answer from student"
+    And I should see "Approve"
+    When I click on the "approve" moodleoverflow review button
+    Then I should see "The post was approved."
+    And I should see "There are no more posts in this forum that need to be reviewed."
+
+  Scenario: A teacher rejects a student post that is pending review
+    Given I navigate as "teacher1" to "Course 1" "Moodleoverflow 1" "Discussion 1"
+    Then I should see "Reject"
+    When I click on the "reject" moodleoverflow review button
+    And I set the field with xpath "//textarea[contains(@class, 'reject-reason')]" to "This post was not good!"
+    And I click on the "reject-submit" moodleoverflow review button
+    Then I should see "The post was rejected."
+    And I should see "There are no more posts in this forum that need to be reviewed."


### PR DESCRIPTION
### 🔀 Purpose of this PR:

- [x] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [ ] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [x] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

The issue: A coding error appeared when trying to approve a post.

The problem: it were actually two bugs in one:

1. db/services.php: the mod_moodleoverflow_review_approve_post web service pointed to a non-existent class/file (external\approve_post / approve_post.php). When accessing the service through the site administratino moodle could not find it. It was fixed by adding the missing class name prefix (approve_post.php -> review_approve_post.php)

2. classes/models/post.ph:  from_record() used !empty($record->reviewed) ? ... : 1, which turned every pending post (reviewed = 0) into reviewed = 1 when loaded. Since the discussion view loads all posts through from_record(), the pending badge and the Approve/Reject buttons never rendered. The review moderation UI was effectively dead.
It was fixed by preserving the real DB value ($record->reviewed ?? 1), so reviewed = 0 stays pending

A new behat test was added that covers the review approve/reject post functionality 

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [x] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.

---

### 🔍 Related Issues

- Related to #275 
