### PR TITLE
Improve unenrolled check in post control

### DIFF
--- a/classes/post/post_control.php
+++ b/classes/post/post_control.php
@@ -936,7 +936,7 @@ class post_control {
      */
     private function catch_unenrolled(): void {
         global $SESSION;
-        if (!isguestuser() && !is_enrolled($this->info->coursecontext)) {
+        if (!isguestuser() && !is_enrolled($this->info->coursecontext) && !is_viewing($this->info->coursecontext)) {
             if (enrol_selfenrol_available($this->info->course->id)) {
                 $SESSION->wantsurl = qualified_me();
                 $SESSION->enrolcancel = get_local_referer(false);


### PR DESCRIPTION

- [x] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [ ] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

The `post_control` was missing a check for users with elevated roles that are viewing a discussion or a post and are not enrolled in the course.

Thanks to @andreajuettner for noticing this!

---

### 🔍 Related Issues

- Related to #279