### PR TITLE
Remove duplicated title in the navigation breadcrumb

### DIFF
--- a/discussion.php
+++ b/discussion.php
@@ -117,9 +117,6 @@ if (empty($forumnode)) {
 $url = new moodle_url('/mod/moodleoverflow/discussion.php', ['d' => $discussion->get_id()]);
 $node = $forumnode->add(format_string($discussion->name), $url);
 $node->display = false;
-if ($node) {
-    $node->add(format_string($discussion->name), $PAGE->url);
-}
 
 $PAGE->requires->js_call_amd('mod_moodleoverflow/reviewing', 'init');
 


### PR DESCRIPTION
### 🔀 Purpose of this PR:

- [x] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [ ] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

The breadcrumbs on the discussion page had the discussion title duplicated. This is now fixed.

Thanks to @andreajuettner for noticing!

---

### 🔍 Related Issues

- Related to #280
